### PR TITLE
Update actions/checkout to latest version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
     # ROS 1 tests only run on Ubuntu
     runs-on: ubuntu-18.04
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - uses: actions/setup-node@v1
       with:
         node-version: '12.x'
@@ -52,7 +52,7 @@ jobs:
       image: ubuntu:xenial
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - uses: actions/setup-node@v1
       with:
         node-version: '12.x'
@@ -80,7 +80,7 @@ jobs:
       image: ubuntu:bionic
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - uses: actions/setup-node@v1
       with:
         node-version: '12.x'
@@ -110,7 +110,7 @@ jobs:
       matrix:
           os: [macOS-latest, ubuntu-18.04, windows-latest]
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - uses: actions/setup-node@v1
       with:
         node-version: '12.x'
@@ -197,7 +197,7 @@ jobs:
       image: ubuntu:bionic
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - uses: actions/setup-node@v1
       with:
         node-version: '12.x'
@@ -226,7 +226,7 @@ jobs:
       image: ubuntu:bionic
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - uses: actions/setup-node@v1
       with:
         node-version: '12.x'


### PR DESCRIPTION
There have been CI failures on PRs due to failures in checkout action ([example](https://github.com/ros-tooling/action-ros-ci/pull/88/checks?check_run_id=461359348#step:2:385)).

Bumping the checkout action to latest version might help fix that.

Signed-off-by: Prajakta Gokhale <prajaktg@amazon.com>