### PR TITLE
Allow vcs-repo-file-url to be empty

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,53 +17,6 @@ env:
   CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
 jobs:
-  test_no_repos_file:
-    name: "Test ROS package"
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        ros_distribution:  # ROS 1 tests only run on Ubuntu
-          - kinetic
-          - melodic
-
-        # Define the Docker image(s) associated with each ROS distribution.
-        # The include syntax allows additional variables to be defined, like
-        # docker_image in this case. See documentation:
-        # https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#example-including-configurations-in-a-matrix-build
-        #
-        # Platforms are defined in REP 3: https://ros.org/reps/rep-0003.html
-        include:
-          # Kinetic Kame (May 2016 - May 2021)
-          - docker_image: ubuntu:xenial
-            ros_distribution: kinetic
-
-          # Melodic Morenia (May 2018 - May 2023)
-          - docker_image: ubuntu:bionic
-            ros_distribution: melodic
-    container:
-      image: ${{ matrix.docker_image }}
-    env:
-      GITHUB_REPOSITORY: ros/ros_tutorials
-      GITHUB_HEAD_REF: ${{ matrix.ros_distribution }}-devel
-    steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-node@v1
-      with:
-        node-version: '12.x'
-    - run: .github/workflows/build-and-test.sh
-    - uses: ros-tooling/setup-ros@0.0.18
-      with:
-        required-ros-distributions: ${{ matrix.ros_distribution }}
-    - uses: ./
-      id: action-ros-ci
-      with:
-        source-ros-binary-installation: ${{ matrix.ros_distribution }}
-        vcs-repo-file-url: ""
-        package-name: roscpp_tutorials
-    - run: test -d "${{ steps.action-ros-ci.outputs.ros-workspace-directory-name }}/install/roscpp_tutorials"
-      name: "Check that roscpp_tutorials install directory is present"
-
   test_ros:
     name: "Test ROS package"
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,55 @@ env:
   CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
 jobs:
+  test_no_repos_file:
+    name: "Test ROS package"
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ros_distribution:  # ROS 1 tests only run on Ubuntu
+          - kinetic
+          - melodic
+
+        # Define the Docker image(s) associated with each ROS distribution.
+        # The include syntax allows additional variables to be defined, like
+        # docker_image in this case. See documentation:
+        # https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#example-including-configurations-in-a-matrix-build
+        #
+        # Platforms are defined in REP 3: https://ros.org/reps/rep-0003.html
+        include:
+          # Kinetic Kame (May 2016 - May 2021)
+          - docker_image: ubuntu:xenial
+            ros_distribution: kinetic
+
+          # Melodic Morenia (May 2018 - May 2023)
+          - docker_image: ubuntu:bionic
+            ros_distribution: melodic
+    container:
+      image: ${{ matrix.docker_image }}
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/checkout@v2
+      with:
+        repository: ros/ros_tutorials
+        ref: ${{ matrix.ros_distribution }}-devel
+        path: ros_ws/src/ros_tutorials
+    - uses: actions/setup-node@v1
+      with:
+        node-version: '12.x'
+    - run: .github/workflows/build-and-test.sh
+    - uses: ros-tooling/setup-ros@0.0.18
+      with:
+        required-ros-distributions: ${{ matrix.ros_distribution }}
+    - uses: ./
+      id: action-ros-ci
+      with:
+        source-ros-binary-installation: ${{ matrix.ros_distribution }}
+        vcs-repo-file-url: ""
+        package-name: roscpp_tutorials
+    - run: test -d "${{ steps.action-ros-ci.outputs.ros-workspace-directory-name }}/install/roscpp_tutorials"
+      name: "Check that roscpp_tutorials install directory is present"
+
   test_ros:
     name: "Test ROS package"
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,13 +43,11 @@ jobs:
             ros_distribution: melodic
     container:
       image: ${{ matrix.docker_image }}
+    env:
+      GITHUB_REPOSITORY: ros/ros_tutorials
+      GITHUB_HEAD_REF: ${{ matrix.ros_distribution }}-devel
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/checkout@v2
-      with:
-        repository: ros/ros_tutorials
-        ref: ${{ matrix.ros_distribution }}-devel
-        path: ros_ws/src/ros_tutorials
     - uses: actions/setup-node@v1
       with:
         node-version: '12.x'

--- a/dist/index.js
+++ b/dist/index.js
@@ -4902,7 +4902,7 @@ function run() {
             const sourceRosBinaryInstallationList = sourceRosBinaryInstallation
                 ? sourceRosBinaryInstallation.split(RegExp("\\s"))
                 : [];
-            const vcsRepoFileUrlListAsString = core.getInput("vcs-repo-file-url");
+            const vcsRepoFileUrlListAsString = core.getInput("vcs-repo-file-url") || "";
             const vcsRepoFileUrlList = vcsRepoFileUrlListAsString.split(RegExp("\\s"));
             const vcsRepoFileUrlListNonEmpty = vcsRepoFileUrlList.filter(x => x != "");
             const vcsRepoFileUrlListResolved = vcsRepoFileUrlListNonEmpty.map(x => resolveVcsRepoFileUrl(x));

--- a/dist/index.js
+++ b/dist/index.js
@@ -4902,9 +4902,7 @@ function run() {
             const sourceRosBinaryInstallationList = sourceRosBinaryInstallation
                 ? sourceRosBinaryInstallation.split(RegExp("\\s"))
                 : [];
-            const vcsRepoFileUrlListAsString = core.getInput("vcs-repo-file-url", {
-                required: true
-            });
+            const vcsRepoFileUrlListAsString = core.getInput("vcs-repo-file-url");
             const vcsRepoFileUrlList = vcsRepoFileUrlListAsString.split(RegExp("\\s"));
             const vcsRepoFileUrlListNonEmpty = vcsRepoFileUrlList.filter(x => x != "");
             const vcsRepoFileUrlListResolved = vcsRepoFileUrlListNonEmpty.map(x => resolveVcsRepoFileUrl(x));

--- a/src/action-ros-ci.ts
+++ b/src/action-ros-ci.ts
@@ -130,9 +130,7 @@ async function run() {
 			? sourceRosBinaryInstallation.split(RegExp("\\s"))
 			: [];
 
-		const vcsRepoFileUrlListAsString = core.getInput("vcs-repo-file-url", {
-			required: true
-		});
+		const vcsRepoFileUrlListAsString = core.getInput("vcs-repo-file-url");
 		const vcsRepoFileUrlList = vcsRepoFileUrlListAsString.split(RegExp("\\s"));
 		const vcsRepoFileUrlListNonEmpty = vcsRepoFileUrlList.filter(x => x != "");
 		const vcsRepoFileUrlListResolved = vcsRepoFileUrlListNonEmpty.map(x =>

--- a/src/action-ros-ci.ts
+++ b/src/action-ros-ci.ts
@@ -130,7 +130,7 @@ async function run() {
 			? sourceRosBinaryInstallation.split(RegExp("\\s"))
 			: [];
 
-		const vcsRepoFileUrlListAsString = core.getInput("vcs-repo-file-url");
+		const vcsRepoFileUrlListAsString = core.getInput("vcs-repo-file-url") || "";
 		const vcsRepoFileUrlList = vcsRepoFileUrlListAsString.split(RegExp("\\s"));
 		const vcsRepoFileUrlListNonEmpty = vcsRepoFileUrlList.filter(x => x != "");
 		const vcsRepoFileUrlListResolved = vcsRepoFileUrlListNonEmpty.map(x =>


### PR DESCRIPTION
Since `action-ros-ci` will commonly be used for building the repo that invokes it (and it generates a valid temporary `package.repo` file for use on-the-fly), there will be many cases where a custom full-blown `.repo` file will not be necessary. These cases should be fulfilled by passing in an empty string for the `vcs-repo-file-url`, which is what this pull request enables.