### PR TITLE
[WIP] Add foxy support to ROS 2 matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -96,9 +96,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ros_distribution:  # ROS 1 tests only run on Ubuntu
+        ros_distribution:
           - dashing
           - eloquent
+          - foxy
 
         # Define the Docker image(s) associated with each ROS distribution.
         # The include syntax allows additional variables to be defined, like
@@ -114,6 +115,10 @@ jobs:
           # Eloquent Elusor (November 2019 - November 2020)
           - docker_image: ubuntu:bionic
             ros_distribution: eloquent
+
+          # Foxy Fitzroy (May 2020 - May 2023)
+          - docker_image: ubuntu:focal
+            ros_distribution: foxy
     container:
       image: ${{ matrix.docker_image }}
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -127,7 +127,7 @@ jobs:
       with:
         node-version: '12.x'
     - run: .github/workflows/build-and-test.sh
-    - uses: ros-tooling/setup-ros@0.0.18
+    - uses: ros-tooling/setup-ros@0.0.20
       with:
         required-ros-distributions: ${{ matrix.ros_distribution }}
 


### PR DESCRIPTION
Add Foxy support.
~~This may fix the issue with flake8~~ If this does fix `action-ros-ci` for Foxy, it is still required to work in `Dashing` and `Eloquent`.

This PR is blocked on flake8 being fixed for the tests.