### PR TITLE
Add the ability to specify arbitrary colcon arguments.

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -23,6 +23,11 @@ inputs:
     description: |
         Additional flags passed to CMake (using colcon build --cmake-args)
     required: false
+  colcon-extra-args:
+    default: ''
+    description: |
+        Arbitrary space-separated additional flags to pass to colcon.
+    required: false
   package-name:
     description: |
         Name of the package(s) under test, as expected by colcon.

--- a/dist/index.js
+++ b/dist/index.js
@@ -4894,6 +4894,7 @@ function run() {
             const colconMixinName = core.getInput("colcon-mixin-name");
             const colconMixinRepo = core.getInput("colcon-mixin-repository");
             const extraCmakeArgs = core.getInput("extra-cmake-args");
+            const colconExtraArgs = core.getInput("colcon-extra-args");
             const packageName = core.getInput("package-name", { required: true });
             const packageNameList = packageName.split(RegExp("\\s"));
             const rosWorkspaceName = "ros_ws";
@@ -4983,6 +4984,9 @@ function run() {
             let extra_options = [];
             if (colconMixinName !== "") {
                 extra_options = extra_options.concat(["--mixin", colconMixinName]);
+            }
+            if (colconExtraArgs !== "") {
+                extra_options = extra_options.concat(colconExtraArgs);
             }
             // Add the future install bin directory to PATH.
             // This enables cmake find_package to find packages installed in the

--- a/src/action-ros-ci.ts
+++ b/src/action-ros-ci.ts
@@ -119,6 +119,7 @@ async function run() {
 		const colconMixinName = core.getInput("colcon-mixin-name");
 		const colconMixinRepo = core.getInput("colcon-mixin-repository");
 		const extraCmakeArgs = core.getInput("extra-cmake-args");
+		const colconExtraArgs = core.getInput("colcon-extra-args");
 		const packageName = core.getInput("package-name", { required: true });
 		const packageNameList = packageName.split(RegExp("\\s"));
 		const rosWorkspaceName = "ros_ws";
@@ -259,6 +260,9 @@ async function run() {
 		let extra_options: string[] = [];
 		if (colconMixinName !== "") {
 			extra_options = extra_options.concat(["--mixin", colconMixinName]);
+		}
+		if (colconExtraArgs !== "") {
+			extra_options = extra_options.concat(colconExtraArgs);
 		}
 
 		// Add the future install bin directory to PATH.


### PR DESCRIPTION
This has uses, for instance, on Windows, where we need to
pass `--merge-install` in order to successfully build.  But
I can also see it as a safety-hatch to do arbitrary colcon
things in a pipeline.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>