### PR TITLE
Add import-token option to use with private repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,18 @@ GitHub workflows can persist data generated in workers during the build using [a
     - if: always()  # upload the logs even when the build fails
 ```
 
+### Use with a private repo
+
+If using `action-ros-ci` with a private repo, it needs a personal access token to be able to checkout the code.
+Generate a [personal access token](https://github.com/settings/tokens) with the "repo" scope and add it to your repo's [secrets][creating-encrypted-secrets].
+For example, if your secret is called `REPO_TOKEN`:
+
+```yaml
+    - uses: ros-tooling/action-ros-ci@0.0.15
+      with:
+        package-name: my_package
+        import-token: ${{ secrets.REPO_TOKEN }}
+```
 
 ## License
 

--- a/action.yml
+++ b/action.yml
@@ -28,6 +28,13 @@ inputs:
     description: |
         Arbitrary space-separated additional flags to pass to colcon.
     required: false
+  import-token:
+    default: ''
+    description: |
+        GitHub personal access token (PAT) to use to import the repository.
+        Useful if the repo is private.
+        The PAT should have the "repo" scope.
+    required: false
   package-name:
     description: |
         Name of the package(s) under test, as expected by colcon.

--- a/dist/index.js
+++ b/dist/index.js
@@ -3299,6 +3299,7 @@ function run() {
             const colconMixinRepo = core.getInput("colcon-mixin-repository");
             const extraCmakeArgs = core.getInput("extra-cmake-args");
             const colconExtraArgs = core.getInput("colcon-extra-args");
+            const importToken = core.getInput("import-token");
             const packageName = core.getInput("package-name", { required: true });
             const packageNameList = packageName.split(RegExp("\\s"));
             const rosWorkspaceName = "ros_ws";
@@ -3356,13 +3357,17 @@ function run() {
             if (github.context.payload.pull_request) {
                 repoFullName = github.context.payload.pull_request.head.repo.full_name;
             }
+            let tokenAuth = importToken;
+            if (tokenAuth !== "") {
+                tokenAuth = tokenAuth.concat("@");
+            }
             const headRef = process.env.GITHUB_HEAD_REF;
             const commitRef = headRef || github.context.sha;
             const repoFilePath = path.join(rosWorkspaceDir, "package.repo");
             const repoFileContent = `repositories:
   ${repo["repo"]}:
     type: git
-    url: 'https://github.com/${repoFullName}.git'
+    url: 'https://${tokenAuth}github.com/${repoFullName}.git'
     version: '${commitRef}'`;
             fs_1.default.writeFileSync(repoFilePath, repoFileContent);
             yield execBashCommand("vcs import --force --recursive src/ < package.repo", commandPrefix, options);

--- a/src/action-ros-ci.ts
+++ b/src/action-ros-ci.ts
@@ -120,6 +120,7 @@ async function run() {
 		const colconMixinRepo = core.getInput("colcon-mixin-repository");
 		const extraCmakeArgs = core.getInput("extra-cmake-args");
 		const colconExtraArgs = core.getInput("colcon-extra-args");
+		const importToken = core.getInput("import-token");
 		const packageName = core.getInput("package-name", { required: true });
 		const packageNameList = packageName.split(RegExp("\\s"));
 		const rosWorkspaceName = "ros_ws";
@@ -202,13 +203,17 @@ async function run() {
 		if (github.context.payload.pull_request) {
 			repoFullName = github.context.payload.pull_request.head.repo.full_name;
 		}
+		let tokenAuth = importToken;
+		if (tokenAuth !== "") {
+			tokenAuth = tokenAuth.concat("@");
+		}
 		const headRef = process.env.GITHUB_HEAD_REF as string;
 		const commitRef = headRef || github.context.sha;
 		const repoFilePath = path.join(rosWorkspaceDir, "package.repo");
 		const repoFileContent = `repositories:
   ${repo["repo"]}:
     type: git
-    url: 'https://github.com/${repoFullName}.git'
+    url: 'https://${tokenAuth}github.com/${repoFullName}.git'
     version: '${commitRef}'`;
 		fs.writeFileSync(repoFilePath, repoFileContent);
 		await execBashCommand(


### PR DESCRIPTION
This adds a new `import-token` input to be used when importing a private repo. Otherwise the step fails with the following error on `vcs import`, since it tries to read a username and a password from stdin:

> `fatal: could not read Username for 'https://github.com': No such device or address`

The token is used in the HTTPS URL itself, e.g.: `https://[token@]github.com/user/repo.git`

Closes #224

Note that this doesn't use the approach suggested in #224. This is more of a simple workaround given the current logic.