### PR TITLE
Increase unit test timeout for slow Windows runs

### DIFF
--- a/__tests__/ros-ci.test.ts
+++ b/__tests__/ros-ci.test.ts
@@ -1,7 +1,7 @@
 import * as core from '@actions/core'
 import {execBashCommand} from '../src/action-ros-ci'
 
-jest.setTimeout(10000);  // in milliseconds
+jest.setTimeout(20000);  // in milliseconds
 
 describe('execBashCommand test suite', () => {
   it('calls coreGroup', async () => {


### PR DESCRIPTION
`action-ros-ci` for windows is slower than other tests.

Example run:
* https://github.com/ros-tooling/action-ros-ci/runs/870055757?check_suite_focus=true

The command is run but doesn't have enough time to complete before it times out.