### PR TITLE
Check out the correct ros2 sources for a given ROS 2 distribution

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -259,10 +259,12 @@ jobs:
           # Dashing Diademata (May 2019 - May 2021)
           - docker_image: ubuntu:bionic
             ros_distribution: dashing
+            distro_repos_url: https://raw.githubusercontent.com/ros2/ros2/dashing/ros2.repos
 
           # Eloquent Elusor (November 2019 - November 2020)
           - docker_image: ubuntu:bionic
             ros_distribution: eloquent
+            distro_repos_url: https://raw.githubusercontent.com/ros2/ros2/eloquent/ros2.repos
     container:
       image: ${{ matrix.docker_image }}
     steps:
@@ -276,6 +278,7 @@ jobs:
       id: test_single_package
       with:
         package-name: ament_copyright
+        vcs-repo-file-url: ${{ distro_repos_url }}
     - run: test -d "${{ steps.test_single_package.outputs.ros-workspace-directory-name }}/install/ament_copyright"
       name: "Check that ament_copyright install directory is present"
 
@@ -284,6 +287,7 @@ jobs:
       name: "Test multiple package, default options"
       with:
         package-name: ament_copyright ament_lint
+        vcs-repo-file-url: ${{ distro_repos_url }}
     - run: test -d "${{ steps.test_multiple_packages.outputs.ros-workspace-directory-name }}/install/ament_copyright"
       name: "Check that ament_copyright install directory is present"
     - run: test -d "${{ steps.test_multiple_packages.outputs.ros-workspace-directory-name }}/install/ament_lint"
@@ -296,6 +300,7 @@ jobs:
         colcon-mixin-name: asan
         colcon-mixin-repository: https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml
         package-name: ament_copyright
+        vcs-repo-file-url: ${{ distro_repos_url }}
     - run: test -d "${{ steps.test_mixin.outputs.ros-workspace-directory-name }}/install/ament_copyright"
       name: "Check that ament_copyright install directory is present"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -278,7 +278,7 @@ jobs:
       id: test_single_package
       with:
         package-name: ament_copyright
-        vcs-repo-file-url: ${{ distro_repos_url }}
+        vcs-repo-file-url: ${{ matrix.distro_repos_url }}
     - run: test -d "${{ steps.test_single_package.outputs.ros-workspace-directory-name }}/install/ament_copyright"
       name: "Check that ament_copyright install directory is present"
 
@@ -287,7 +287,7 @@ jobs:
       name: "Test multiple package, default options"
       with:
         package-name: ament_copyright ament_lint
-        vcs-repo-file-url: ${{ distro_repos_url }}
+        vcs-repo-file-url: ${{ matrix.distro_repos_url }}
     - run: test -d "${{ steps.test_multiple_packages.outputs.ros-workspace-directory-name }}/install/ament_copyright"
       name: "Check that ament_copyright install directory is present"
     - run: test -d "${{ steps.test_multiple_packages.outputs.ros-workspace-directory-name }}/install/ament_lint"
@@ -300,7 +300,7 @@ jobs:
         colcon-mixin-name: asan
         colcon-mixin-repository: https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml
         package-name: ament_copyright
-        vcs-repo-file-url: ${{ distro_repos_url }}
+        vcs-repo-file-url: ${{ matrix.distro_repos_url }}
     - run: test -d "${{ steps.test_mixin.outputs.ros-workspace-directory-name }}/install/ament_copyright"
       name: "Check that ament_copyright install directory is present"
 


### PR DESCRIPTION
Check out the correct ros2 sources for a given ROS 2 distribution when doing linter tests on this Action.

Part of solution for https://github.com/ros-tooling/aws-oncall/issues/139
Resolves failing builds for Dashing and Eloquent linting tests on this repository.
See this build https://github.com/ros-tooling/action-ros-ci/runs/870259660?check_suite_focus=true

This failure was revealed (but not caused) by https://github.com/ament/ament_lint/pull/241 - which used a Python 3.8 feature - showing us that we were checking out the latest version of ament_lint, instead of the distro-appropriate branches.

Signed-off-by: Emerson Knapp <eknapp@amazon.com>