### PR TITLE
mark colcon-coveragepy-result as required dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This action requires the following ROS development tools to be installed (and in
 curl
 colcon-common-extensions
 colcon-lcov-result  # Optional
-colcon-coveragepy-result  # Optional
+colcon-coveragepy-result
 colcon-mixin
 rosdep
 vcstool


### PR DESCRIPTION
A job using action-ros-ci without that dependency installed [will fail](https://github.com/mikaelarguedas/sros2/runs/870838891?check_suite_focus=true):
```
  /usr/bin/bash -c colcon coveragepy-result 				--packages-select sros2 sros2_cmake test_security
  usage: colcon [-h] [--log-base LOG_BASE] [--log-level LOG_LEVEL]
                {build,extension-points,extensions,graph,info,list,metadata,mixin,test,test-result,version-check}
                ...
  colcon: error: argument verb_name: invalid choice: 'coveragepy-result' (choose from 'build', 'extension-points', 'extensions', 'graph', 'info', 'list', 'metadata', 'mixin', 'test', 'test-result', 'version-check')
##[error]The process '/usr/bin/bash' failed with exit code 2
```
Related to https://github.com/ros-tooling/action-ros-ci/issues/238#issuecomment-652025665