### PR TITLE
Fix messaging and logic from #278

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -148,13 +148,13 @@ jobs:
     - run: test -d "${{ steps.test_single_package.outputs.ros-workspace-directory-name }}/install/osrf_testing_tools_cpp"
 
   test_ros2_from_source:
-    name: "Test ROS 2 package"
+    name: "Test ROS 2 package from source"
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-          os: [macOS-latest, windows-latest]
-          ros_distribution: [eloquent, foxy]
+          os: [macOS-latest, windows-latest, ubuntu-latest]
+          ros_distribution: [foxy]
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-node@v1
@@ -285,7 +285,7 @@ jobs:
     - uses: ros-tooling/setup-ros@0.0.25
       with:
         required-ros-distributions: ${{ matrix.ros_distribution }}
-    
+
     - uses: ./
       id: test_single_package
       with:

--- a/__tests__/ros-ci.test.ts
+++ b/__tests__/ros-ci.test.ts
@@ -29,8 +29,13 @@ describe('execBashCommand test suite', () => {
 })
 
 describe("validate distribution test", () => {
-	it("test valid", async () => {
-		const obj = {t1: "kinetic", t2: "", cmd: ""};
-		await expect(actionRosCi.validateDistro(obj)).toBe(true);
-	});
+  it("validates that the ros distribution validator acts correctly", async () => {
+  expect(actionRosCi.validateDistros("kinetic", "")).toBe(true);
+    expect(actionRosCi.validateDistros("melodic", "dashing")).toBe(true);
+    expect(actionRosCi.validateDistros("", "eloquent")).toBe(true);
+    expect(actionRosCi.validateDistros("", "")).toBe(false);
+    expect(actionRosCi.validateDistros("groovy", "")).toBe(false);
+    expect(actionRosCi.validateDistros("", "bouncy")).toBe(false);
+    expect(actionRosCi.validateDistros("apples", "bananas")).toBe(false);
+  });
 });

--- a/dist/index.js
+++ b/dist/index.js
@@ -3226,16 +3226,16 @@ const curlFlagsArray = [
 ];
 const validROS1Distros = ["kinetic", "lunar", "melodic", "noetic"];
 const validROS2Distros = ["dashing", "eloquent", "foxy"];
-const target_ros1_distro_input = "target-ros1-distro";
-const target_ros2_distro_input = "target-ros2-distro";
-const is_linux = process.platform == "linux";
-const is_windows = process.platform == "win32";
+const targetROS1DistroInput = "target-ros1-distro";
+const targetROS2DistroInput = "target-ros2-distro";
+const isLinux = process.platform == "linux";
+const isWindows = process.platform == "win32";
 /**
  * Convert local paths to URLs.
  *
  * The user can pass the VCS repo file either as a URL or a path.
  * If it is a path, this function will convert it into a URL (file://...).
- * If the file is already passed as an URL, this function does nothing.
+
  *
  * @param   vcsRepoFileUrl     path or URL to the repo file
  * @returns                    URL to the repo file
@@ -3264,7 +3264,7 @@ function execBashCommand(commandLine, commandPrefix, options, log_message) {
         const message = log_message || `Invoking "bash -c '${bashScript}'`;
         let toolRunnerCommandLine = "";
         let toolRunnerCommandLineArgs = [];
-        if (is_windows) {
+        if (isWindows) {
             toolRunnerCommandLine = "C:\\Windows\\system32\\cmd.exe";
             // This passes the same flags to cmd.exe that "run:" in a workflow.
             // https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#using-a-specific-shell
@@ -3300,24 +3300,24 @@ exports.execBashCommand = execBashCommand;
 function validateDistro(obj) {
     if (!obj.t1 && !obj.t2) {
         obj.cmd +=
-            `Neither '${target_ros1_distro_input}' or '${target_ros2_distro_input}' inputs were set, at least one is required.`;
+            `Neither '${targetROS1DistroInput}' or '${targetROS2DistroInput}' inputs were set, at least one is required.`;
         return false;
     }
     if (obj.t1) {
         if (validROS1Distros.indexOf(obj.t1) <= -1) {
-            obj.cmd += `Input ${obj.t1} was not a valid ROS 1 distribution for '${target_ros1_distro_input}'. Valid values: ${validROS1Distros}`;
+            obj.cmd += `Input ${obj.t1} was not a valid ROS 1 distribution for '${targetROS1DistroInput}'. Valid values: ${validROS1Distros}`;
             return false;
         }
-        if (is_linux) {
+        if (isLinux) {
             obj.cmd += `mkdir -p /opt/ros/${obj.t1} && touch /opt/ros/${obj.t1}/setup.sh} && source /opt/ros/${obj.t1}/setup.sh && `;
         }
     }
     if (obj.t2) {
         if (validROS2Distros.indexOf(obj.t2) <= -1) {
-            obj.cmd += `Input ${obj.t2} was not a valid ROS 2 distribution for '${target_ros2_distro_input}'. Valid values: ${validROS2Distros}`;
+            obj.cmd += `Input ${obj.t2} was not a valid ROS 2 distribution for '${targetROS2DistroInput}'. Valid values: ${validROS2Distros}`;
             return false;
         }
-        if (is_linux) {
+        if (isLinux) {
             obj.cmd += `mkdir -p /opt/ros/${obj.t2} && touch /opt/ros/${obj.t2}/setup.sh} && source /opt/ros/${obj.t2}/setup.sh && `;
         }
     }
@@ -3338,8 +3338,8 @@ function run() {
             const packageNameList = packageName.split(RegExp("\\s"));
             const rosWorkspaceName = "ros_ws";
             const rosWorkspaceDir = path.join(workspace, rosWorkspaceName);
-            const targetRos1Distro = core.getInput(target_ros1_distro_input);
-            const targetRos2Distro = core.getInput(target_ros2_distro_input);
+            const targetRos1Distro = core.getInput(targetROS1DistroInput);
+            const targetRos2Distro = core.getInput(targetROS2DistroInput);
             const vcsRepoFileUrlListAsString = core.getInput("vcs-repo-file-url") || "";
             const vcsRepoFileUrlList = vcsRepoFileUrlListAsString.split(RegExp("\\s"));
             const vcsRepoFileUrlListNonEmpty = vcsRepoFileUrlList.filter((x) => x != "");
@@ -3358,7 +3358,7 @@ function run() {
             commandPrefix = obj.cmd;
             // rosdep on Windows does not reliably work on Windows, see
             // ros-infrastructure/rosdep#610 for instance. So, we do not run it.
-            if (is_windows) {
+            if (!isWindows) {
                 yield execBashCommand("rosdep update", commandPrefix);
             }
             // Reset colcon configuration.
@@ -3379,7 +3379,7 @@ function run() {
             // We do not want to allow the "default" head state of the package to
             // to be present in the workspace, and colcon will fail stating it found twice
             // a package with an identical name.
-            const posixRosWorkspaceDir = is_windows
+            const posixRosWorkspaceDir = isWindows
                 ? rosWorkspaceDir.replace(/\\/g, "/")
                 : rosWorkspaceDir;
             yield execBashCommand(`find "${posixRosWorkspaceDir}" -type d -and -name "${repo["repo"]}" | xargs rm -rf`, commandPrefix);
@@ -3443,7 +3443,7 @@ function run() {
 			--packages-up-to ${packageNameList.join(" ")} \
 			${extra_options.join(" ")} \
 			--cmake-args ${extraCmakeArgs}`;
-            if (process.platform !== "win32") {
+            if (!isWindows) {
                 colconBuildCmd = colconBuildCmd.concat(" --symlink-install");
             }
             yield execBashCommand(colconBuildCmd, commandPrefix, options);

--- a/dist/index.js
+++ b/dist/index.js
@@ -3189,7 +3189,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.validateDistro = exports.execBashCommand = void 0;
+exports.validateDistros = exports.execBashCommand = void 0;
 const core = __importStar(__webpack_require__(470));
 const github = __importStar(__webpack_require__(469));
 const tr = __importStar(__webpack_require__(686));
@@ -3235,7 +3235,7 @@ const isWindows = process.platform == "win32";
  *
  * The user can pass the VCS repo file either as a URL or a path.
  * If it is a path, this function will convert it into a URL (file://...).
-
+ * If the file is already passed as an URL, this function does nothing.
  *
  * @param   vcsRepoFileUrl     path or URL to the repo file
  * @returns                    URL to the repo file
@@ -3297,33 +3297,22 @@ function execBashCommand(commandLine, commandPrefix, options, log_message) {
 }
 exports.execBashCommand = execBashCommand;
 //Determine whether all inputs name supported ROS distributions.
-function validateDistro(obj) {
-    if (!obj.t1 && !obj.t2) {
-        obj.cmd +=
-            `Neither '${targetROS1DistroInput}' or '${targetROS2DistroInput}' inputs were set, at least one is required.`;
+function validateDistros(ros1Distro, ros2Distro) {
+    if (!ros1Distro && !ros2Distro) {
+        core.setFailed(`Neither '${targetROS1DistroInput}' or '${targetROS2DistroInput}' inputs were set, at least one is required.`);
         return false;
     }
-    if (obj.t1) {
-        if (validROS1Distros.indexOf(obj.t1) <= -1) {
-            obj.cmd += `Input ${obj.t1} was not a valid ROS 1 distribution for '${targetROS1DistroInput}'. Valid values: ${validROS1Distros}`;
-            return false;
-        }
-        if (isLinux) {
-            obj.cmd += `mkdir -p /opt/ros/${obj.t1} && touch /opt/ros/${obj.t1}/setup.sh} && source /opt/ros/${obj.t1}/setup.sh && `;
-        }
+    if (ros1Distro && validROS1Distros.indexOf(ros1Distro) <= -1) {
+        core.setFailed(`Input ${ros1Distro} was not a valid ROS 1 distribution for '${targetROS1DistroInput}'. Valid values: ${validROS1Distros}`);
+        return false;
     }
-    if (obj.t2) {
-        if (validROS2Distros.indexOf(obj.t2) <= -1) {
-            obj.cmd += `Input ${obj.t2} was not a valid ROS 2 distribution for '${targetROS2DistroInput}'. Valid values: ${validROS2Distros}`;
-            return false;
-        }
-        if (isLinux) {
-            obj.cmd += `mkdir -p /opt/ros/${obj.t2} && touch /opt/ros/${obj.t2}/setup.sh} && source /opt/ros/${obj.t2}/setup.sh && `;
-        }
+    if (ros2Distro && validROS2Distros.indexOf(ros2Distro) <= -1) {
+        core.setFailed(`Input ${ros2Distro} was not a valid ROS 2 distribution for '${targetROS2DistroInput}'. Valid values: ${validROS2Distros}`);
+        return false;
     }
     return true;
 }
-exports.validateDistro = validateDistro;
+exports.validateDistros = validateDistros;
 function run() {
     return __awaiter(this, void 0, void 0, function* () {
         try {
@@ -3345,17 +3334,19 @@ function run() {
             const vcsRepoFileUrlListNonEmpty = vcsRepoFileUrlList.filter((x) => x != "");
             const vcsRepoFileUrlListResolved = vcsRepoFileUrlListNonEmpty.map((x) => resolveVcsRepoFileUrl(x));
             const coverageIgnorePattern = core.getInput("coverage-ignore-pattern");
-            let commandPrefix = "";
-            const obj = {
-                t1: targetRos1Distro,
-                t2: targetRos2Distro,
-                cmd: commandPrefix,
-            };
-            if (!validateDistro(obj)) {
-                core.setFailed(obj.cmd);
+            if (!validateDistros(targetRos1Distro, targetRos2Distro)) {
                 return;
             }
-            commandPrefix = obj.cmd;
+            // Source any installed ROS binary distribution, safely creating an empty setup file if it is not present
+            let commandPrefix = "";
+            if (isLinux) {
+                if (targetRos1Distro) {
+                    commandPrefix += `mkdir -p /opt/ros/${targetRos1Distro} && touch /opt/ros/${targetRos1Distro}/setup.sh && source /opt/ros/${targetRos1Distro}/setup.sh && `;
+                }
+                if (targetRos2Distro) {
+                    commandPrefix += `mkdir -p /opt/ros/${targetRos2Distro} && touch /opt/ros/${targetRos2Distro}/setup.sh && source /opt/ros/${targetRos2Distro}/setup.sh && `;
+                }
+            }
             // rosdep on Windows does not reliably work on Windows, see
             // ros-infrastructure/rosdep#610 for instance. So, we do not run it.
             if (!isWindows) {

--- a/src/action-ros-ci.ts
+++ b/src/action-ros-ci.ts
@@ -40,17 +40,17 @@ const curlFlagsArray = [
 
 const validROS1Distros: string[] = ["kinetic", "lunar", "melodic", "noetic"];
 const validROS2Distros: string[] = ["dashing", "eloquent", "foxy"];
-const target_ros1_distro_input: string = "target-ros1-distro";
-const target_ros2_distro_input: string = "target-ros2-distro";
-const is_linux: boolean = process.platform == "linux";
-const is_windows: boolean = process.platform == "win32";
+const targetROS1DistroInput: string = "target-ros1-distro";
+const targetROS2DistroInput: string = "target-ros2-distro";
+const isLinux: boolean = process.platform == "linux";
+const isWindows: boolean = process.platform == "win32";
 
 /**
  * Convert local paths to URLs.
  *
  * The user can pass the VCS repo file either as a URL or a path.
  * If it is a path, this function will convert it into a URL (file://...).
- * If the file is already passed as an URL, this function does nothing.
+
  *
  * @param   vcsRepoFileUrl     path or URL to the repo file
  * @returns                    URL to the repo file
@@ -84,7 +84,7 @@ export async function execBashCommand(
 
 	let toolRunnerCommandLine = "";
 	let toolRunnerCommandLineArgs: string[] = [];
-	if (is_windows) {
+	if (isWindows) {
 		toolRunnerCommandLine = "C:\\Windows\\system32\\cmd.exe";
 		// This passes the same flags to cmd.exe that "run:" in a workflow.
 		// https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#using-a-specific-shell
@@ -123,27 +123,27 @@ export async function execBashCommand(
 export function validateDistro(obj: { t1; t2; cmd }): boolean {
 	if (!obj.t1 && !obj.t2) {
 		obj.cmd +=
-			`Neither '${target_ros1_distro_input}' or '${target_ros2_distro_input}' inputs were set, at least one is required.`;
+			`Neither '${targetROS1DistroInput}' or '${targetROS2DistroInput}' inputs were set, at least one is required.`;
 
 		return false;
 	}
 	if (obj.t1) {
 		if (validROS1Distros.indexOf(obj.t1) <= -1) {
-			obj.cmd += `Input ${obj.t1} was not a valid ROS 1 distribution for '${target_ros1_distro_input}'. Valid values: ${validROS1Distros}`;
+			obj.cmd += `Input ${obj.t1} was not a valid ROS 1 distribution for '${targetROS1DistroInput}'. Valid values: ${validROS1Distros}`;
 
 			return false;
 		}
-		if (is_linux) {
+		if (isLinux) {
 			obj.cmd += `mkdir -p /opt/ros/${obj.t1} && touch /opt/ros/${obj.t1}/setup.sh} && source /opt/ros/${obj.t1}/setup.sh && `;
 		}
 	}
 	if (obj.t2) {
 		if (validROS2Distros.indexOf(obj.t2) <= -1) {
-			obj.cmd += `Input ${obj.t2} was not a valid ROS 2 distribution for '${target_ros2_distro_input}'. Valid values: ${validROS2Distros}`;
+			obj.cmd += `Input ${obj.t2} was not a valid ROS 2 distribution for '${targetROS2DistroInput}'. Valid values: ${validROS2Distros}`;
 
 			return false;
 		}
-		if (is_linux) {
+		if (isLinux) {
 			obj.cmd += `mkdir -p /opt/ros/${obj.t2} && touch /opt/ros/${obj.t2}/setup.sh} && source /opt/ros/${obj.t2}/setup.sh && `;
 		}
 	}
@@ -165,8 +165,8 @@ async function run() {
 		const packageNameList = packageName.split(RegExp("\\s"));
 		const rosWorkspaceName = "ros_ws";
 		const rosWorkspaceDir = path.join(workspace, rosWorkspaceName);
-		const targetRos1Distro = core.getInput(target_ros1_distro_input);
-		const targetRos2Distro = core.getInput(target_ros2_distro_input);
+		const targetRos1Distro = core.getInput(targetROS1DistroInput);
+		const targetRos2Distro = core.getInput(targetROS2DistroInput);
 		const vcsRepoFileUrlListAsString = core.getInput("vcs-repo-file-url") || "";
 		const vcsRepoFileUrlList = vcsRepoFileUrlListAsString.split(RegExp("\\s"));
 		const vcsRepoFileUrlListNonEmpty = vcsRepoFileUrlList.filter(
@@ -195,7 +195,7 @@ async function run() {
 
 		// rosdep on Windows does not reliably work on Windows, see
 		// ros-infrastructure/rosdep#610 for instance. So, we do not run it.
-		if (is_windows) {
+		if (!isWindows) {
 			await execBashCommand("rosdep update", commandPrefix);
 		}
 
@@ -227,7 +227,7 @@ async function run() {
 		// to be present in the workspace, and colcon will fail stating it found twice
 		// a package with an identical name.
 		const posixRosWorkspaceDir =
-			is_windows
+			isWindows
 				? rosWorkspaceDir.replace(/\\/g, "/")
 				: rosWorkspaceDir;
 		await execBashCommand(
@@ -322,7 +322,7 @@ async function run() {
 			--packages-up-to ${packageNameList.join(" ")} \
 			${extra_options.join(" ")} \
 			--cmake-args ${extraCmakeArgs}`;
-		if (process.platform !== "win32") {
+		if (!isWindows) {
 			colconBuildCmd = colconBuildCmd.concat(" --symlink-install");
 		}
 		await execBashCommand(colconBuildCmd, commandPrefix, options);


### PR DESCRIPTION
* Pull argument name strings into constants 
* Clean up logic around distro validation and add more tests
* Add an e2e test for Ubuntu to build from source with no binary installation, which would have caught the shell script typo

Signed-off-by: Emerson Knapp <eknapp@amazon.com>