### PR TITLE
Add rolling to list of valid ROS 2 distros

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -154,7 +154,7 @@ jobs:
       fail-fast: false
       matrix:
           os: [macOS-latest, windows-latest, ubuntu-latest]
-          ros_distribution: [foxy]
+          ros_distribution: [foxy, rolling]
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-node@v1

--- a/dist/index.js
+++ b/dist/index.js
@@ -3225,7 +3225,7 @@ const curlFlagsArray = [
     "--location",
 ];
 const validROS1Distros = ["kinetic", "lunar", "melodic", "noetic"];
-const validROS2Distros = ["dashing", "eloquent", "foxy"];
+const validROS2Distros = ["dashing", "eloquent", "foxy", "rolling"];
 const targetROS1DistroInput = "target-ros1-distro";
 const targetROS2DistroInput = "target-ros2-distro";
 const isLinux = process.platform == "linux";

--- a/src/action-ros-ci.ts
+++ b/src/action-ros-ci.ts
@@ -39,7 +39,7 @@ const curlFlagsArray = [
 ];
 
 const validROS1Distros: string[] = ["kinetic", "lunar", "melodic", "noetic"];
-const validROS2Distros: string[] = ["dashing", "eloquent", "foxy"];
+const validROS2Distros: string[] = ["dashing", "eloquent", "foxy", "rolling"];
 const targetROS1DistroInput: string = "target-ros1-distro";
 const targetROS2DistroInput: string = "target-ros2-distro";
 const isLinux: boolean = process.platform == "linux";


### PR DESCRIPTION
This adds `rolling` to the list of valid ROS 2 distros. It allows users to develop & test against the latest source.

I've also added rolling to the `ros_distribution` list in the `test_ros2_from_source` test job.

Fixes #286