### PR TITLE
Run Foxy tests on Ubuntu Focal instead of Bionic

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -153,7 +153,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-          os: [macOS-latest, windows-latest, ubuntu-latest]
+          os: [macOS-latest, windows-latest, ubuntu-20.04]
           ros_distribution: [foxy, rolling]
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
This switches from 18.04 to 20.04 for Foxy tests. `ubuntu-latest` still refers to Ubuntu 18.04 Bionic. See: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idruns-on

I think the tests weren't failing because they were using very basic packages (`ament_copyright`/`ament_lint`) that don't have many system dependencies, so the odds of something breaking were probably quite low.