### PR TITLE
When detecting host os, use runner.os, not matrix.os

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,10 +86,10 @@ jobs:
         target-ros2-distro: ${{ matrix.ros_distribution }}
         vcs-repo-file-url: "${{ github.workspace }}/.github/workflows/repo_file_for_test_cpp_package.repos"
       # TODO(tmoulard): re-enable this test once it passes on Windows
-      if: matrix.os != 'windows-latest'
+      if: runner.os != 'Windows'
     - run: test -d "${{ steps.test_single_package.outputs.ros-workspace-directory-name }}/install/osrf_testing_tools_cpp"
       # TODO(tmoulard): re-enable this test once it passes on Windows
-      if: matrix.os != 'windows-latest'
+      if: runner.os != 'Windows'
 
   test_ros2_foxy_package_with_dependencies:
     name: "Test ROS 2 foxy package with ROS dependencies"
@@ -245,10 +245,10 @@ jobs:
         package-name: osrf_testing_tools_cpp
         target-ros2-distro: ${{ matrix.ros_distribution }}
         vcs-repo-file-url: "${{ github.workspace }}/.github/workflows/repo_file_for_test_cpp_package.repos"
-      if: matrix.os != 'windows-latest'
+      if: runner.os != 'Windows'
     - run: find ${{ steps.test_coverage.outputs.ros-workspace-directory-name }}/build -name "*.gcda" | grep -q "."
       name: "Check if one or more code coverage files (*.gcda) are present (Linux only)"
-      if: matrix.os != 'windows-latest'
+      if: runner.os != 'Windows'
 
     - uses: ./
       id: test_extra_cmake


### PR DESCRIPTION
This is a more direct check, allowing future Windows versions and self-hosted runners

Signed-off-by: Dan Rose <dan@digilabs.io>
