### PR TITLE
Handle workspace directories with same name as repository under test

### DIFF
--- a/.github/workflows/repo_file_for_test_dirs_with_same_name_as_repo.repos
+++ b/.github/workflows/repo_file_for_test_dirs_with_same_name_as_repo.repos
@@ -1,0 +1,17 @@
+# Similar to repo_file_for_test.repos, but with different directory names
+repositories:
+  # Test having a top-level directory with the same name as the test repo
+  action-ros-ci/foo:
+    type: git
+    url: https://github.com/ament/ament_cmake.git
+    version: 0.8.1
+  # Test having a child directory with the same name as the test repo
+  foo/action-ros-ci/bar:
+    type: git
+    url: https://github.com/ament/ament_lint.git
+    version: 0.8.1
+  # Test having a duplicate of the test repo
+  ros-tooling/action-ros-ci:
+    type: git
+    url: https://github.com/ros-tooling/action-ros-ci.git
+    version: master

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -391,6 +391,16 @@ jobs:
       - run: grep -q 9ae391a63628efe6d72ba34a1a1d9dc9 ./${{ steps.test_extra_cmake.outputs.ros-workspace-directory-name }}/build/ament_cmake_core/CMakeCache.txt
         name: "Check that the additional extra flags has been correctly passed"
 
+      - uses: ./
+        id: test_directories_with_same_name_as_repo
+        name: "Test that directories with the same name as this repository are not removed"
+        with:
+          package-name: ament_copyright
+          target-ros2-distro: ${{ matrix.ros_distribution }}
+          vcs-repo-file-url: "${{ github.workspace }}/.github/workflows/repo_file_for_test_dirs_with_same_name_as_repo.repos"
+      - run: test -d "${{ steps.test_directories_with_same_name_as_repo.outputs.ros-workspace-directory-name }}/src/action-ros-ci/foo"
+      - run: test -d "${{ steps.test_directories_with_same_name_as_repo.outputs.ros-workspace-directory-name }}/src/foo/action-ros-ci/bar"
+
   log_workflow_status_to_cloudwatch:
     runs-on: ubuntu-latest
     container:

--- a/dist/index.js
+++ b/dist/index.js
@@ -10610,8 +10610,10 @@ function run() {
             const headRef = process.env.GITHUB_HEAD_REF;
             const commitRef = headRef || github.context.sha;
             const repoFilePath = path.join(rosWorkspaceDir, "package.repo");
+            // Add a random string prefix to avoid naming collisions when checking out the test repository
+            const randomStringPrefix = Math.random().toString(36).substring(2, 15);
             const repoFileContent = `repositories:
-  ${repo["repo"]}:
+  ${randomStringPrefix}/${repo["repo"]}:
     type: git
     url: 'https://${tokenAuth}github.com/${repoFullName}.git'
     version: '${commitRef}'`;

--- a/dist/index.js
+++ b/dist/index.js
@@ -10595,7 +10595,7 @@ function run() {
             const posixRosWorkspaceDir = isWindows
                 ? rosWorkspaceDir.replace(/\\/g, "/")
                 : rosWorkspaceDir;
-            yield execBashCommand(`find "${posixRosWorkspaceDir}" -type d -and -name "${repo["repo"]}" | xargs rm -rf`);
+            yield execBashCommand(`vcs diff -s --repos ${posixRosWorkspaceDir} | cut -d ' ' -f 1 | grep "${repo["repo"]}$" | xargs rm -rf`);
             // The repo file for the repository needs to be generated on-the-fly to
             // incorporate the custom repository URL and branch name, when a PR is
             // being built.

--- a/src/action-ros-ci.ts
+++ b/src/action-ros-ci.ts
@@ -230,8 +230,10 @@ async function run() {
 		const headRef = process.env.GITHUB_HEAD_REF as string;
 		const commitRef = headRef || github.context.sha;
 		const repoFilePath = path.join(rosWorkspaceDir, "package.repo");
+		// Add a random string prefix to avoid naming collisions when checking out the test repository
+		const randomStringPrefix = Math.random().toString(36).substring(2, 15);
 		const repoFileContent = `repositories:
-  ${repo["repo"]}:
+  ${randomStringPrefix}/${repo["repo"]}:
     type: git
     url: 'https://${tokenAuth}github.com/${repoFullName}.git'
     version: '${commitRef}'`;

--- a/src/action-ros-ci.ts
+++ b/src/action-ros-ci.ts
@@ -213,7 +213,7 @@ async function run() {
 			? rosWorkspaceDir.replace(/\\/g, "/")
 			: rosWorkspaceDir;
 		await execBashCommand(
-			`find "${posixRosWorkspaceDir}" -type d -and -name "${repo["repo"]}" | xargs rm -rf`
+			`vcs diff -s --repos ${posixRosWorkspaceDir} | cut -d ' ' -f 1 | grep "${repo["repo"]}$" | xargs rm -rf`
 		);
 
 		// The repo file for the repository needs to be generated on-the-fly to


### PR DESCRIPTION
Fixes https://github.com/ros-tooling/action-ros-ci/issues/342.

To fix the issue for my use-case, I had to introduce two patches:

1. Remove the vcs repository directory instead of any directory with the same name as the repository (892f4dd)
Use 'vcs diff' as a hack to list the root directories of repositories in the workspace, then cut the ' (git)' suffix, and grep for the repository name.
This should be a little more robust than the previous logic, which may accidentally remove parent and child directories that happen to have the same name as the repository being tested.

2. Add random string prefix to repository path in workspace (4be073c)
This is to avoid naming collisions when checking out the test repository.

Before: https://github.com/osrf/ros2_java/runs/1087011472
After: https://github.com/osrf/ros2_java/runs/1093909689