### PR TITLE
Infer default ros2 repos file from target-ros2-distro

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -85,6 +85,7 @@ jobs:
           package-name: osrf_testing_tools_cpp
           target-ros2-distro: ${{ matrix.ros_distribution }}
           vcs-repo-file-url: "${{ github.workspace }}/.github/workflows/repo_file_for_test_cpp_package.repos"
+          which-ros2-repos: ""
         # TODO(tmoulard): re-enable this test once it passes on Windows
         if: runner.os != 'Windows'
       - run: test -d "${{ steps.test_single_package.outputs.ros-workspace-directory-name }}/install/osrf_testing_tools_cpp"
@@ -104,6 +105,7 @@ jobs:
           package-name: rmw
           target-ros2-distro: foxy
           vcs-repo-file-url: "${{ github.workspace }}/.github/workflows/repo_file_for_test_cpp_with_dependency.repos"
+          which-ros2-repos: ""
 
   test_ros2_docker:
     name: "ROS 2 Docker"
@@ -153,6 +155,7 @@ jobs:
           # test_msgs depends on test_interface_files, which should be installed by rosdep
           # If the dependencies are installed for the wrong distribution, then the build should fail
           package-name: test_msgs
+          which-ros2-repos: ""
       # Verify that rosdep installed the required Debian package
       - run: dpkg -s ros-${{ matrix.ros_distribution }}-test-interface-files
 
@@ -163,6 +166,7 @@ jobs:
           package-name: osrf_testing_tools_cpp
           target-ros2-distro: ${{ matrix.ros_distribution }}
           vcs-repo-file-url: "${{ github.workspace }}/.github/workflows/repo_file_for_test_cpp_package.repos"
+          which-ros2-repos: ""
       - run: test -d "${{ steps.test_single_package.outputs.ros-workspace-directory-name }}/install/osrf_testing_tools_cpp"
 
   test_ros2_from_source:
@@ -217,6 +221,7 @@ jobs:
           vcs-repo-file-url: "${{ github.workspace }}/.github/workflows/repo_file_for_test.repos"
           package-name: ament_copyright
           target-ros2-distro: ${{ matrix.ros_distribution }}
+          which-ros2-repos: ""
       - run: test -d "${{ steps.test_repo.outputs.ros-workspace-directory-name }}/install/ament_copyright"
 
       # The second repo file is ignored, but will get vcs-import'ed anyway.
@@ -231,6 +236,7 @@ jobs:
             .github/workflows/repo_file_for_test_cpp_package.repos
           package-name: ament_copyright
           target-ros2-distro: ${{ matrix.ros_distribution }}
+          which-ros2-repos: ""
       - run: test -d "${{ steps.test_multiple_repos.outputs.ros-workspace-directory-name }}/install/ament_copyright"
       - run: test -d "${{ steps.test_multiple_repos.outputs.ros-workspace-directory-name }}/src/ament_lint"
       - run: test -d "${{ steps.test_multiple_repos.outputs.ros-workspace-directory-name }}/src/osrf_testing_tools_cpp"
@@ -244,6 +250,7 @@ jobs:
           package-name: osrf_testing_tools_cpp
           target-ros2-distro: ${{ matrix.ros_distribution }}
           vcs-repo-file-url: "${{ github.workspace }}/.github/workflows/repo_file_for_test_cpp_package.repos"
+          which-ros2-repos: ""
         if: runner.os != 'Windows'
       - run: find ${{ steps.test_coverage.outputs.ros-workspace-directory-name }}/build -name "*.gcda" | grep -q "."
         name: "Check if one or more code coverage files (*.gcda) are present (Linux only)"
@@ -256,6 +263,7 @@ jobs:
           package-name: ament_cmake_core
           target-ros2-distro: ${{ matrix.ros_distribution }}
           vcs-repo-file-url: "${{ github.workspace }}/.github/workflows/repo_file_for_test.repos"
+          which-ros2-repos: ""
           # We use a long unique string here to make sure that if this string
           # is found in CMakeCache.txt, it means the additional CMake flag has
           # been passed successfully. Non recognized flags are also written by
@@ -310,6 +318,7 @@ jobs:
           package-name: ament_copyright
           target-ros2-distro: ${{ matrix.ros_distribution }}
           vcs-repo-file-url: ${{ matrix.distro_repos_url }}
+          which-ros2-repos: ""
       - run: test -d "${{ steps.test_single_package.outputs.ros-workspace-directory-name }}/install/ament_copyright"
         name: "Check that ament_copyright install directory is present"
 
@@ -320,6 +329,7 @@ jobs:
           package-name: ament_copyright ament_lint
           target-ros2-distro: ${{ matrix.ros_distribution }}
           vcs-repo-file-url: ${{ matrix.distro_repos_url }}
+          which-ros2-repos: ""
       - run: test -d "${{ steps.test_multiple_packages.outputs.ros-workspace-directory-name }}/install/ament_copyright"
         name: "Check that ament_copyright install directory is present"
       - run: test -d "${{ steps.test_multiple_packages.outputs.ros-workspace-directory-name }}/install/ament_lint"
@@ -334,6 +344,7 @@ jobs:
           package-name: ament_copyright
           target-ros2-distro: ${{ matrix.ros_distribution }}
           vcs-repo-file-url: ${{ matrix.distro_repos_url }}
+          which-ros2-repos: ""
       - run: test -d "${{ steps.test_mixin.outputs.ros-workspace-directory-name }}/install/ament_copyright"
         name: "Check that ament_copyright install directory is present"
 
@@ -344,6 +355,7 @@ jobs:
           vcs-repo-file-url: "${{ github.workspace }}/.github/workflows/repo_file_for_test.repos"
           package-name: ament_copyright
           target-ros2-distro: ${{ matrix.ros_distribution }}
+          which-ros2-repos: ""
       - run: test -d "${{ steps.test_repo.outputs.ros-workspace-directory-name }}/install/ament_copyright"
 
       # The second repo file is ignored, but will get vcs-import'ed anyway.
@@ -358,6 +370,7 @@ jobs:
             .github/workflows/repo_file_for_test_cpp_package.repos
           package-name: ament_copyright
           target-ros2-distro: ${{ matrix.ros_distribution }}
+          which-ros2-repos: ""
       - run: test -d "${{ steps.test_multiple_repos.outputs.ros-workspace-directory-name }}/install/ament_copyright"
       - run: test -d "${{ steps.test_multiple_repos.outputs.ros-workspace-directory-name }}/src/ament_lint"
       - run: test -d "${{ steps.test_multiple_repos.outputs.ros-workspace-directory-name }}/src/osrf_testing_tools_cpp"
@@ -371,6 +384,7 @@ jobs:
           package-name: osrf_testing_tools_cpp
           target-ros2-distro: ${{ matrix.ros_distribution }}
           vcs-repo-file-url: "${{ github.workspace }}/.github/workflows/repo_file_for_test_cpp_package.repos"
+          which-ros2-repos: ""
       - run: find ${{ steps.test_coverage.outputs.ros-workspace-directory-name }}/build -name "*.gcda" | grep -q "."
         name: "Check if one or more code coverage files (*.gcda) are present (Linux only)"
 
@@ -381,6 +395,7 @@ jobs:
           package-name: ament_cmake_core
           target-ros2-distro: ${{ matrix.ros_distribution }}
           vcs-repo-file-url: "${{ github.workspace }}/.github/workflows/repo_file_for_test.repos"
+          which-ros2-repos: ""
           # We use a long unique string here to make sure that if this string
           # is found in CMakeCache.txt, it means the additional CMake flag has
           # been passed successfully. Non recognized flags are also written by
@@ -398,6 +413,7 @@ jobs:
           package-name: ament_copyright
           target-ros2-distro: ${{ matrix.ros_distribution }}
           vcs-repo-file-url: "${{ github.workspace }}/.github/workflows/repo_file_for_test_dirs_with_same_name_as_repo.repos"
+          which-ros2-repos: ""
       - run: test -d "${{ steps.test_directories_with_same_name_as_repo.outputs.ros-workspace-directory-name }}/src/action-ros-ci/foo"
       - run: test -d "${{ steps.test_directories_with_same_name_as_repo.outputs.ros-workspace-directory-name }}/src/foo/action-ros-ci/bar"
 

--- a/action.yml
+++ b/action.yml
@@ -60,8 +60,16 @@ inputs:
   vcs-repo-file-url:
     description: |
       repo file URL passed to vcs to initialize the colcon workspace.
-      The URL may point to a local file, such as file://path/to/file.txt
-    default: "https://raw.githubusercontent.com/ros2/ros2/master/ros2.repos"
+      The URL may point to a local file, such as file://path/to/file.txt.
+    default: null
+  which-ros2-repos:
+    description: |
+      Each ROS distribution has 
+      Which repos file to pull distro ros2 packages from. One of:
+      "" (no default repos file),
+      "develop" (possibly immature packages),
+      "release" (source code of released packages)
+    default: "develop"
 outputs:
   ros-workspace-directory-name:
     description: |


### PR DESCRIPTION
* Now specifying a ros distro will use the corresponding ros2.repos file by default
* The new "which-ros2-repos" controls whether to use e.g. foxy ("develop") or foxy-release ("release")