### PR TITLE
Update everything to 0.1.0 for release

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,7 +49,7 @@ jobs:
         with:
           node-version: "12.x"
       - run: .github/workflows/build-and-test.sh
-      - uses: ros-tooling/setup-ros@0.0.25
+      - uses: ros-tooling/setup-ros@0.0.26
         with:
           required-ros-distributions: ${{ matrix.ros_distribution }}
       - uses: ./
@@ -75,7 +75,7 @@ jobs:
         with:
           node-version: "12.x"
       - run: .github/workflows/build-and-test.sh
-      - uses: ros-tooling/setup-ros@0.0.25
+      - uses: ros-tooling/setup-ros@0.0.26
         with:
           required-ros-distributions: ${{ matrix.ros_distribution }}
       - uses: ./
@@ -96,7 +96,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
-      - uses: ros-tooling/setup-ros@0.0.25
+      - uses: ros-tooling/setup-ros@0.0.26
         with:
           required-ros-distributions: foxy
       - uses: ./
@@ -141,7 +141,7 @@ jobs:
         with:
           node-version: "12.x"
       - run: .github/workflows/build-and-test.sh
-      - uses: ros-tooling/setup-ros@0.0.25
+      - uses: ros-tooling/setup-ros@0.0.26
         with:
           required-ros-distributions: ${{ matrix.ros_distribution }}
 
@@ -179,7 +179,7 @@ jobs:
         with:
           node-version: "12.x"
       - run: .github/workflows/build-and-test.sh
-      - uses: ros-tooling/setup-ros@0.0.25
+      - uses: ros-tooling/setup-ros@0.0.26
       - uses: ./
         id: test_single_package
         with:
@@ -300,7 +300,7 @@ jobs:
         with:
           node-version: "12.x"
       - run: .github/workflows/build-and-test.sh
-      - uses: ros-tooling/setup-ros@0.0.25
+      - uses: ros-tooling/setup-ros@0.0.26
         with:
           required-ros-distributions: ${{ matrix.ros_distribution }}
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ See [action.yml](action.yml) to get the list of flags supported by this action.
 ```yaml
 steps:
   - uses: ros-tooling/setup-ros@0.0.25
-  - uses: ros-tooling/action-ros-ci@0.0.18
+  - uses: ros-tooling/action-ros-ci@0.1.0
     with:
       package-name: ament_copyright
       target-ros2-distro: foxy
@@ -76,7 +76,7 @@ steps:
       rosinstall_generator <package-name> --rosdistro <target-distro> \
       --deps-only --deps --upstream-development > /tmp/deps.repos
   # Pass the file to the action
-  - uses: ros-tooling/action-ros-ci@0.0.18
+  - uses: ros-tooling/action-ros-ci@0.1.0
     with:
       package-name: my_package
       target-ros2-distro: foxy
@@ -93,7 +93,7 @@ steps:
   - uses: ros-tooling/setup-ros@0.0.25
     with:
       required-ros-distributions: melodic
-  - uses: ros-tooling/action-ros-ci@0.0.18
+  - uses: ros-tooling/action-ros-ci@0.1.0
     with:
       package-name: my_package
       target-ros1-distro: melodic
@@ -108,7 +108,7 @@ memory corruption bugs.
 ```yaml
 steps:
   - uses: ros-tooling/setup-ros@0.0.25
-  - uses: ros-tooling/action-ros-ci@0.0.18
+  - uses: ros-tooling/action-ros-ci@0.1.0
     with:
       colcon-mixin-name: asan
       colcon-mixin-repository: https://raw.githubusercontent.com/colcon/colcon-mixin-repository/3e627e0fa30db85aea05a50e2c61a9832664d236/index.yaml
@@ -138,7 +138,7 @@ preferable to use a `colcon` mixin to pass the appropriate flags automatically.
 ```yaml
 steps:
   - uses: ros-tooling/setup-ros@0.0.25
-  - uses: ros-tooling/action-ros-ci@0.0.18
+  - uses: ros-tooling/action-ros-ci@0.1.0
     with:
       package-name: my_package
       target-ros2-distro: foxy
@@ -160,7 +160,7 @@ preferable to use a `colcon` mixin to pass the appropriate flags automatically.
 ```yaml
 steps:
   - uses: ros-tooling/setup-ros@0.0.25
-  - uses: ros-tooling/action-ros-ci@0.0.18
+  - uses: ros-tooling/action-ros-ci@0.1.0
     with:
       package-name: my_package
       target-ros2-distro: foxy
@@ -180,7 +180,7 @@ See [action/codecov-action](https://github.com/codecov/codecov-action) documenta
 ```yaml
 steps:
   - uses: ros-tooling/setup-ros@0.0.25
-  - uses: ros-tooling/action-ros-ci@0.0.18
+  - uses: ros-tooling/action-ros-ci@0.1.0
     with:
       package-name: my_package
       target-ros2-distro: foxy
@@ -210,7 +210,7 @@ The configuration file is required to let codecov map the workspace directory st
 GitHub workflows can persist data generated in workers during the build using [artifacts](persisting-workflow-data-using-artifacts). `action-ros-ci` generated colcon logs can be saved as follows:
 
 ```yaml
-- uses: ros-tooling/action-ros-ci@0.0.18
+- uses: ros-tooling/action-ros-ci@0.1.0
   id: action_ros_ci_step
   with:
     package-name: ament_copyright
@@ -229,7 +229,7 @@ Generate a [personal access token](https://github.com/settings/tokens) with the 
 For example, if your secret is called `REPO_TOKEN`:
 
 ```yaml
-- uses: ros-tooling/action-ros-ci@0.0.18
+- uses: ros-tooling/action-ros-ci@0.1.0
   with:
     package-name: my_package
     import-token: ${{ secrets.REPO_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ See [action.yml](action.yml) to get the list of flags supported by this action.
 
 ```yaml
 steps:
-  - uses: ros-tooling/setup-ros@0.0.25
+  - uses: ros-tooling/setup-ros@0.0.26
   - uses: ros-tooling/action-ros-ci@0.1.0
     with:
       package-name: ament_copyright
@@ -70,7 +70,7 @@ You can also automatically generate your package's dependencies using the follow
 ```yaml
 steps:
   - uses: actions/checkout@v2
-  - uses: ros-tooling/setup-ros@0.0.25
+  - uses: ros-tooling/setup-ros@0.0.26
   # Run the generator and output the results to a file.
   - run: |
       rosinstall_generator <package-name> --rosdistro <target-distro> \
@@ -90,7 +90,7 @@ This tool supports building for both ROS and ROS 2 - to target ROS use `target-r
 ```yaml
 steps:
   - uses: actions/checkout@v2
-  - uses: ros-tooling/setup-ros@0.0.25
+  - uses: ros-tooling/setup-ros@0.0.26
     with:
       required-ros-distributions: melodic
   - uses: ros-tooling/action-ros-ci@0.1.0
@@ -107,7 +107,7 @@ memory corruption bugs.
 
 ```yaml
 steps:
-  - uses: ros-tooling/setup-ros@0.0.25
+  - uses: ros-tooling/setup-ros@0.0.26
   - uses: ros-tooling/action-ros-ci@0.1.0
     with:
       colcon-mixin-name: asan
@@ -137,7 +137,7 @@ preferable to use a `colcon` mixin to pass the appropriate flags automatically.
 
 ```yaml
 steps:
-  - uses: ros-tooling/setup-ros@0.0.25
+  - uses: ros-tooling/setup-ros@0.0.26
   - uses: ros-tooling/action-ros-ci@0.1.0
     with:
       package-name: my_package
@@ -159,7 +159,7 @@ preferable to use a `colcon` mixin to pass the appropriate flags automatically.
 
 ```yaml
 steps:
-  - uses: ros-tooling/setup-ros@0.0.25
+  - uses: ros-tooling/setup-ros@0.0.26
   - uses: ros-tooling/action-ros-ci@0.1.0
     with:
       package-name: my_package
@@ -179,7 +179,7 @@ See [action/codecov-action](https://github.com/codecov/codecov-action) documenta
 
 ```yaml
 steps:
-  - uses: ros-tooling/setup-ros@0.0.25
+  - uses: ros-tooling/setup-ros@0.0.26
   - uses: ros-tooling/action-ros-ci@0.1.0
     with:
       package-name: my_package

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "action-ros-ci",
-	"version": "0.0.18",
+	"version": "0.1.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "action-ros-ci",
-	"version": "0.0.18",
+	"version": "0.1.0",
 	"description": "GitHub Action compiling and testing a ROS 2 package",
 	"main": "lib/main.js",
 	"scripts": {


### PR DESCRIPTION
Fixes #429 - addPath deprecation error by updating dependencies.

Moves to minor version 1 in order to allow for better communicating API change vs patch fixes in the future (without committing to 1.0)

