### PR TITLE
WIP fix kinetic installation by getting new setup-ros with upgraded pip3

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,7 +49,7 @@ jobs:
         with:
           node-version: "12.x"
       - run: .github/workflows/build-and-test.sh
-      - uses: ros-tooling/setup-ros@0.1.0
+      - uses: ros-tooling/setup-ros@emersonknapp/upgrade-pip-before-install-dependencies
         with:
           required-ros-distributions: ${{ matrix.ros_distribution }}
       - uses: ./


### PR DESCRIPTION
Depends on https://github.com/ros-tooling/setup-ros/pull/313

Fixes error found at e.g.  https://github.com/ros-tooling/action-ros-ci/actions/runs/409583561 - a new version of `cryptography` highlighted that we have a very old version of pip3 on Ubuntu Xenial. Upgrading it to latest fixes the issue.

Easily reproducible

```
# Dockerfile
from ubuntu:xenial
run apt-get update && apt-get install python3-pip
# Uncomment the below line and it'll fix the build, without it you can see the breakage
# run pip3 install -U pip 
run pip3 install cryptography
```