### PR TITLE
Don't run dependabot automation jobs on non-dependabot PRs

### DIFF
--- a/.github/workflows/autoapprove.yml
+++ b/.github/workflows/autoapprove.yml
@@ -8,8 +8,8 @@ jobs:
   # (see .dependabot/config.yml for more info).
   auto-approve-dependabot:
     runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]'
     steps:
       - uses: hmarr/auto-approve-action@v2.0.0
-        if: github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]'
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -14,15 +14,13 @@ jobs:
   # Automatically merge approved and green dependabot PRs.
   auto-merge-dependabot:
     runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]'
     steps:
       - uses: pascalgn/automerge-action@v0.12.0
-        if: github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]'
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
           MERGE_LABELS: "dependencies"
           MERGE_METHOD: "squash" # Sqush and merge
           MERGE_COMMIT_MESSAGE: "pull-request-title-and-description"
-          MERGE_RETRY_SLEEP: "1200000" # Retry after 20m, enough time for check suites to run
-          UPDATE_RETRIES: "6"
+          MERGE_RETRIES: "0"
           UPDATE_METHOD: "rebase" # Rebase PR on base branch
-          UPDATE_RETRY_SLEEP: "300000"


### PR DESCRIPTION
Also disable the retry logic for automerge. Dependabot automatically updates its PRs, and the automerge is triggered on check_suite completion, so there is no reason to leave jobs up and spinning. These jobs have been tying up our limited action runners for the free tier, actually slowing down contributions.