### PR TITLE
Include EOL distros in rosdep update - allows builds to continue working after EOL

### DIFF
--- a/src/action-ros-ci.ts
+++ b/src/action-ros-ci.ts
@@ -179,7 +179,7 @@ async function run() {
 		// rosdep does not reliably work on Windows, see
 		// ros-infrastructure/rosdep#610 for instance. So, we do not run it.
 		if (!isWindows) {
-			await execBashCommand("rosdep update");
+			await execBashCommand("rosdep update --include-eol-distros");
 		}
 
 		// Reset colcon configuration.


### PR DESCRIPTION
This should fix the build