### PR TITLE
Fail workflow at the first `colcon list` if a bad package name is specified

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -10556,7 +10556,8 @@ function resolveVcsRepoFileUrl(vcsRepoFileUrl) {
 function execBashCommand(commandLine, commandPrefix, options, log_message) {
     return __awaiter(this, void 0, void 0, function* () {
         commandPrefix = commandPrefix || "";
-        const bashScript = `${commandPrefix} ${commandLine}`;
+        const bashScript = `${commandPrefix}${commandLine}`;
+        const message = log_message || `Invoking: bash -c '${bashScript}'`;
         let toolRunnerCommandLine = "";
         let toolRunnerCommandLineArgs = [];
         if (isWindows) {
@@ -10584,7 +10585,6 @@ function execBashCommand(commandLine, commandPrefix, options, log_message) {
             toolRunnerCommandLine = "bash";
             toolRunnerCommandLineArgs = ["-c", bashScript];
         }
-        const message = log_message || `Invoking: ${toolRunnerCommandLine} ${toolRunnerCommandLineArgs.join(" ")}`;
         const runner = new tr.ToolRunner(toolRunnerCommandLine, toolRunnerCommandLineArgs, options);
         return core.group(message, () => {
             return runner.exec();
@@ -10622,9 +10622,6 @@ function installRosdeps(upToPackages, workspaceDir, ros1Distro, ros2Distro) {
 		echo "Specify rosdistro name as single argument to this script"
 		exit 1
 	fi
-	pwd
-	ls
-	ls src
 	DISTRO=$1
 	package_paths=$(colcon list --paths-only --packages-up-to ${upToPackages})
 	# suppress errors from unresolved install keys to preserve backwards compatibility

--- a/dist/index.js
+++ b/dist/index.js
@@ -10556,8 +10556,7 @@ function resolveVcsRepoFileUrl(vcsRepoFileUrl) {
 function execBashCommand(commandLine, commandPrefix, options, log_message) {
     return __awaiter(this, void 0, void 0, function* () {
         commandPrefix = commandPrefix || "";
-        const bashScript = `${commandPrefix}${commandLine}`;
-        const message = log_message || `Invoking: bash -c '${bashScript}'`;
+        const bashScript = `${commandPrefix} ${commandLine}`;
         let toolRunnerCommandLine = "";
         let toolRunnerCommandLineArgs = [];
         if (isWindows) {
@@ -10585,6 +10584,7 @@ function execBashCommand(commandLine, commandPrefix, options, log_message) {
             toolRunnerCommandLine = "bash";
             toolRunnerCommandLineArgs = ["-c", bashScript];
         }
+        const message = log_message || `Invoking: ${toolRunnerCommandLine} ${toolRunnerCommandLineArgs.join(" ")}`;
         const runner = new tr.ToolRunner(toolRunnerCommandLine, toolRunnerCommandLineArgs, options);
         return core.group(message, () => {
             return runner.exec();
@@ -10609,6 +10609,40 @@ function validateDistros(ros1Distro, ros2Distro) {
     return true;
 }
 exports.validateDistros = validateDistros;
+/**
+  * Install ROS dependencies for given packages in the workspace, for all ROS distros being used.
+  */
+function installRosdeps(upToPackages, workspaceDir, ros1Distro, ros2Distro) {
+    return __awaiter(this, void 0, void 0, function* () {
+        const scriptName = "install_rosdeps.sh";
+        const scriptPath = path.join(workspaceDir, scriptName);
+        const scriptContent = `#!/bin/bash
+	set -euxo pipefail
+	if [ $# != 1 ]; then
+		echo "Specify rosdistro name as single argument to this script"
+		exit 1
+	fi
+	pwd
+	ls
+	ls src
+	DISTRO=$1
+	package_paths=$(colcon list --paths-only --packages-up-to ${upToPackages})
+	# suppress errors from unresolved install keys to preserve backwards compatibility
+	# due to difficulty reading names of some non-catkin dependencies in the ros2 core
+	# see https://index.ros.org/doc/ros2/Installation/Foxy/Linux-Development-Setup/#install-dependencies-using-rosdep
+	DEBIAN_FRONTEND=noninteractive RTI_NC_LICENSE_ACCEPTED=yes rosdep install -r --from-paths $package_paths --ignore-src --rosdistro $DISTRO -y || true`;
+        fs_1.default.writeFileSync(scriptPath, scriptContent, { mode: 0o766 });
+        let exitCode = 0;
+        const options = { cwd: workspaceDir };
+        if (ros1Distro) {
+            exitCode += yield execBashCommand(`./${scriptName} ${ros1Distro}`, "", options);
+        }
+        if (ros2Distro) {
+            exitCode += yield execBashCommand(`./${scriptName} ${ros2Distro}`, "", options);
+        }
+        return exitCode;
+    });
+}
 function run() {
     return __awaiter(this, void 0, void 0, function* () {
         try {
@@ -10619,8 +10653,7 @@ function run() {
             const extraCmakeArgs = core.getInput("extra-cmake-args");
             const colconExtraArgs = core.getInput("colcon-extra-args");
             const importToken = core.getInput("import-token");
-            const packageName = core.getInput("package-name", { required: true });
-            const packageNameList = packageName.split(RegExp("\\s"));
+            const packageNames = core.getInput("package-name", { required: true }).split(RegExp("\\s")).join(" ");
             const rosWorkspaceName = "ros_ws";
             core.setOutput("ros-workspace-directory-name", rosWorkspaceName);
             const rosWorkspaceDir = path.join(workspace, rosWorkspaceName);
@@ -10684,16 +10717,7 @@ function run() {
     version: '${commitRef}'`;
             fs_1.default.writeFileSync(repoFilePath, repoFileContent);
             yield execBashCommand("vcs import --force --recursive src/ < package.repo", undefined, options);
-            // Remove all repositories the package under test does not depend on, to
-            // avoid having rosdep installing unrequired dependencies.
-            yield execBashCommand(`diff --new-line-format="" --unchanged-line-format="" <(colcon list -p) <(colcon list --packages-up-to ${packageNameList.join(" ")} -p) | xargs rm -rf`, undefined, options);
-            // Install ROS dependencies for each distribution being sourced
-            if (targetRos1Distro) {
-                yield execBashCommand(`DEBIAN_FRONTEND=noninteractive RTI_NC_LICENSE_ACCEPTED=yes rosdep install -r --from-paths src --ignore-src --rosdistro ${targetRos1Distro} -y || true`, undefined, options);
-            }
-            if (targetRos2Distro) {
-                yield execBashCommand(`DEBIAN_FRONTEND=noninteractive RTI_NC_LICENSE_ACCEPTED=yes rosdep install -r --from-paths src --ignore-src --rosdistro ${targetRos2Distro} -y || true`, undefined, options);
-            }
+            yield installRosdeps(packageNames, rosWorkspaceDir, targetRos1Distro, targetRos2Distro);
             if (colconMixinName !== "" && colconMixinRepo !== "") {
                 yield execBashCommand(`colcon mixin add default '${colconMixinRepo}'`);
                 yield execBashCommand("colcon mixin update default");
@@ -10747,7 +10771,7 @@ function run() {
             let colconBuildCmd = [
                 `colcon build`,
                 `--event-handlers console_cohesion+`,
-                `--packages-up-to ${packageNameList.join(" ")}`,
+                `--packages-up-to ${packageNames}`,
                 `${extra_options.join(" ")}`,
                 `--cmake-args ${extraCmakeArgs}`,
             ].join(" ");
@@ -10767,7 +10791,7 @@ function run() {
                 `--event-handlers console_cohesion+`,
                 `--pytest-with-coverage`,
                 `--return-code-on-test-failure`,
-                `--packages-select ${packageNameList.join(" ")}`,
+                `--packages-select ${packageNames}`,
                 `${extra_options.join(" ")}`,
             ].join(" ");
             yield execBashCommand(colconTestCmd, colconCommandPrefix, options);
@@ -10775,7 +10799,7 @@ function run() {
             const colconLcovResultCmd = [
                 `colcon lcov-result`,
                 `--filter ${coverageIgnorePattern}`,
-                `--packages-select ${packageNameList.join(" ")}`,
+                `--packages-select ${packageNames}`,
             ].join(" ");
             yield execBashCommand(colconLcovResultCmd, colconCommandPrefix, {
                 cwd: rosWorkspaceDir,
@@ -10783,7 +10807,7 @@ function run() {
             });
             const colconCoveragepyResultCmd = [
                 `colcon coveragepy-result`,
-                `--packages-select ${packageNameList.join(" ")}`,
+                `--packages-select ${packageNames}`,
             ].join(" ");
             yield execBashCommand(colconCoveragepyResultCmd, colconCommandPrefix, options);
             core.setOutput("ros-workspace-directory-name", rosWorkspaceName);

--- a/package-lock.json
+++ b/package-lock.json
@@ -3336,7 +3336,8 @@
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
 			"integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
-			"dev": true
+			"dev": true,
+			"optional": true
 		},
 		"har-schema": {
 			"version": "2.0.0",
@@ -3728,6 +3729,7 @@
 			"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
 			"integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
 			"dev": true,
+			"optional": true,
 			"requires": {
 				"is-docker": "^2.0.0"
 			}
@@ -6139,6 +6141,7 @@
 			"resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-8.0.1.tgz",
 			"integrity": "sha512-BvEXF+UmsnAfYfoapKM9nGxnP+Wn7P91YfXmrKnfcYCx6VBeoN5Ez5Ogck6I8Bi5k4RlpqRYaw75pAwzX9OphA==",
 			"dev": true,
+			"optional": true,
 			"requires": {
 				"growly": "^1.3.0",
 				"is-wsl": "^2.2.0",
@@ -6153,6 +6156,7 @@
 					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
 					"integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"lru-cache": "^6.0.0"
 					}
@@ -6161,13 +6165,15 @@
 					"version": "8.3.2",
 					"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
 					"integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"which": {
 					"version": "2.0.2",
 					"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
 					"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"isexe": "^2.0.0"
 					}
@@ -6914,7 +6920,8 @@
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
 			"integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
-			"dev": true
+			"dev": true,
+			"optional": true
 		},
 		"signal-exit": {
 			"version": "3.0.3",

--- a/src/action-ros-ci.ts
+++ b/src/action-ros-ci.ts
@@ -79,7 +79,9 @@ export async function execBashCommand(
 	log_message?: string
 ): Promise<number> {
 	commandPrefix = commandPrefix || "";
-	const bashScript = `${commandPrefix} ${commandLine}`;
+	const bashScript = `${commandPrefix}${commandLine}`;
+	const message = log_message || `Invoking: bash -c '${bashScript}'`;
+
 	let toolRunnerCommandLine = "";
 	let toolRunnerCommandLineArgs: string[] = [];
 	if (isWindows) {
@@ -106,8 +108,6 @@ export async function execBashCommand(
 		toolRunnerCommandLine = "bash";
 		toolRunnerCommandLineArgs = ["-c", bashScript];
 	}
-
-	const message = log_message || `Invoking: ${toolRunnerCommandLine} ${toolRunnerCommandLineArgs.join(" ")}`;
 	const runner: tr.ToolRunner = new tr.ToolRunner(
 		toolRunnerCommandLine,
 		toolRunnerCommandLineArgs,
@@ -161,9 +161,6 @@ async function installRosdeps(
 		echo "Specify rosdistro name as single argument to this script"
 		exit 1
 	fi
-	pwd
-	ls
-	ls src
 	DISTRO=$1
 	package_paths=$(colcon list --paths-only --packages-up-to ${upToPackages})
 	# suppress errors from unresolved install keys to preserve backwards compatibility


### PR DESCRIPTION
Fixes #364

By adding the `-o pipefail` option to all bash commands, we can intercept failures properly, as in the following case when a bad package name is provided. This causes the workflow to exit at this point, rather than waiting all the way until `colcon build`

```
		await execBashCommand(
			`diff --new-line-format="" --unchanged-line-format="" <(colcon list -p) <(colcon list --packages-up-to ${packageNameList.join(
				" "
			)} -p) | xargs rm -rf`,
			undefined,
			options
		);

```