### PR TITLE
Fix log message for bash commands

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -10557,7 +10557,7 @@ function execBashCommand(commandLine, commandPrefix, options, log_message) {
     return __awaiter(this, void 0, void 0, function* () {
         commandPrefix = commandPrefix || "";
         const bashScript = `${commandPrefix}${commandLine}`;
-        const message = log_message || `Invoking "bash -c '${bashScript}'`;
+        const message = log_message || `Invoking: bash -c '${bashScript}'`;
         let toolRunnerCommandLine = "";
         let toolRunnerCommandLineArgs = [];
         if (isWindows) {

--- a/src/action-ros-ci.ts
+++ b/src/action-ros-ci.ts
@@ -80,7 +80,7 @@ export async function execBashCommand(
 ): Promise<number> {
 	commandPrefix = commandPrefix || "";
 	const bashScript = `${commandPrefix}${commandLine}`;
-	const message = log_message || `Invoking "bash -c '${bashScript}'`;
+	const message = log_message || `Invoking: bash -c '${bashScript}'`;
 
 	let toolRunnerCommandLine = "";
 	let toolRunnerCommandLineArgs: string[] = [];


### PR DESCRIPTION
The closing quotation mark was missing, but I think using a colon like this is cleaner.