### PR TITLE
Set CODEOWNERS for package[-lock].json to @ghost so that dependabot reviews are not auto-assigned to humans

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,5 @@
 # Reviewers (and by extension approvers) will be the default owners for everything in the repo.
 # Unless a later match takes precedence, @reviewers will be requested for review when someone opens a pull request.
-*     @ros-tooling/reviewers
+*                  @ros-tooling/reviewers
+package-lock.json  @ghost
+package.json       @ghost


### PR DESCRIPTION
These reviews are noisy. One side-effect is that somebody changing only `package.json` for real will need to request reviews explicitly. This generally will only happen in version-bumps for release.