### PR TITLE
Skip rti-connext-dds-5.3.1 when running rosdep install

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -185,6 +185,7 @@ jobs:
       - uses: ros-tooling/setup-ros@0.1.2
       - uses: ./
         id: test_single_package
+        name: "Test single package, default options"
         with:
           package-name: ament_copyright
           target-ros2-distro: ${{ matrix.ros_distribution }}
@@ -201,6 +202,15 @@ jobs:
         name: "Check that ament_copyright install directory is present"
       - run: test -d "${{ steps.test_multiple_packages.outputs.ros-workspace-directory-name }}/install/ament_lint"
         name: "Check that ament_lint install directory is present"
+
+      - uses: ./
+        id: test_connext_dependency
+        name: "Test single package with Connext dependency, default options"
+        with:
+          package-name: rmw_implementation
+          target-ros2-distro: ${{ matrix.ros_distribution }}
+      - run: test -d "${{ steps.test_connext_dependency.outputs.ros-workspace-directory-name }}/install/rmw_implementation"
+        name: "Check that rmw_implementation install directory is present"
 
       - uses: ./
         id: test_mixin
@@ -309,6 +319,7 @@ jobs:
 
       - uses: ./
         id: test_single_package
+        name: "Test single package, default options"
         with:
           package-name: ament_copyright
           target-ros2-distro: ${{ matrix.ros_distribution }}
@@ -327,6 +338,16 @@ jobs:
         name: "Check that ament_copyright install directory is present"
       - run: test -d "${{ steps.test_multiple_packages.outputs.ros-workspace-directory-name }}/install/ament_lint"
         name: "Check that ament_lint install directory is present"
+
+      - uses: ./
+        id: test_connext_dependency
+        name: "Test single package with Connext dependency, default options"
+        with:
+          package-name: rmw_implementation
+          target-ros2-distro: ${{ matrix.ros_distribution }}
+          vcs-repo-file-url: ${{ matrix.distro_repos_url }}
+      - run: test -d "${{ steps.test_connext_dependency.outputs.ros-workspace-directory-name }}/install/rmw_implementation"
+        name: "Check that rmw_implementation install directory is present"
 
       - uses: ./
         id: test_mixin

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -206,11 +206,13 @@ jobs:
       - uses: ./
         id: test_connext_dependency
         name: "Test single package with Connext dependency, default options"
+        if: matrix.os == 'ubuntu-20.04'
         with:
           package-name: rmw_implementation
           target-ros2-distro: ${{ matrix.ros_distribution }}
       - run: test -d "${{ steps.test_connext_dependency.outputs.ros-workspace-directory-name }}/install/rmw_implementation"
         name: "Check that rmw_implementation install directory is present"
+        if: matrix.os == 'ubuntu-20.04'
 
       - uses: ./
         id: test_mixin

--- a/dist/index.js
+++ b/dist/index.js
@@ -10975,7 +10975,7 @@ function installRosdeps(upToPackages, workspaceDir, ros1Distro, ros2Distro) {
 	# suppress errors from unresolved install keys to preserve backwards compatibility
 	# due to difficulty reading names of some non-catkin dependencies in the ros2 core
 	# see https://index.ros.org/doc/ros2/Installation/Foxy/Linux-Development-Setup/#install-dependencies-using-rosdep
-	DEBIAN_FRONTEND=noninteractive RTI_NC_LICENSE_ACCEPTED=yes rosdep install -r --from-paths $package_paths --ignore-src --rosdistro $DISTRO -y || true`;
+	rosdep install -r --from-paths $package_paths --ignore-src --skip-keys rti-connext-dds-5.3.1 --rosdistro $DISTRO -y || true`;
         fs_1.default.writeFileSync(scriptPath, scriptContent, { mode: 0o766 });
         let exitCode = 0;
         const options = { cwd: workspaceDir };

--- a/src/action-ros-ci.ts
+++ b/src/action-ros-ci.ts
@@ -168,7 +168,7 @@ async function installRosdeps(
 	# suppress errors from unresolved install keys to preserve backwards compatibility
 	# due to difficulty reading names of some non-catkin dependencies in the ros2 core
 	# see https://index.ros.org/doc/ros2/Installation/Foxy/Linux-Development-Setup/#install-dependencies-using-rosdep
-	DEBIAN_FRONTEND=noninteractive RTI_NC_LICENSE_ACCEPTED=yes rosdep install -r --from-paths $package_paths --ignore-src --rosdistro $DISTRO -y || true`;
+	rosdep install -r --from-paths $package_paths --ignore-src --skip-keys rti-connext-dds-5.3.1 --rosdistro $DISTRO -y || true`;
 	fs.writeFileSync(scriptPath, scriptContent, { mode: 0o766 });
 
 	let exitCode = 0;


### PR DESCRIPTION
Fixes #518

By default, the `setup-ros` action does not install Connext DDS. However, when `action-ros-ci` runs `rosdep install` for a package that depends (directly or not) on `rmw_connext_cpp`, it tries to install `rti-connext-dds-5.3.1` from `apt`.

This fails because `DEBIAN_FRONTEND=noninteractive RTI_NC_LICENSE_ACCEPTED=yes` somehow doesn't work in accepting the Connext DDS license. In any case, I think we should avoid installing Connext DDS in `action-ros-ci` and have users use [`setup-ros`'s `install-connext` option](https://github.com/ros-tooling/setup-ros/blob/222a8c0740c8e8ddb93bcaf37ef482f4f4a3ac11/action.yml#L14-L18).

I've also added a test to catch this (in which case the test will take forever/times out), since the current tests use packages that do not actually depend on any rmw implementation.