### PR TITLE
Support overriding repos files & providing supplemental ones in PRs

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,23 @@ For example, if your secret is called `REPO_TOKEN`:
     import-token: ${{ secrets.REPO_TOKEN }}
 ```
 
+### Interdependent pull requests or merge requests
+
+This action allows declaring PR dependencies by providing:
+* repos file(s) to override the one(s) defined through the `vcs-repo-file-url` action input
+* supplemental repos file(s) to be used along with the rest
+
+For example, this may be useful when your PR depends on PRs/MRs/branches from other repos for it to work or be properly tested.
+
+Include links in your PR's description using the following format:
+
+```
+action-ros-ci-repos-override: https://gist.github.com/some-user/some.repos
+action-ros-ci-repos-override: https://gist.github.com/some-user/some-other.repos
+action-ros-ci-repos-supplemental: https://gist.github.com/some-user/some-supplemental.repos
+action-ros-ci-repos-supplemental: file://path/to/some/other/supplemental.repos
+```
+
 ## License
 
 The scripts and documentation in this project are released under the [Apache 2](LICENSE) license.

--- a/__tests__/ros-ci.test.ts
+++ b/__tests__/ros-ci.test.ts
@@ -1,5 +1,6 @@
 import * as core from "@actions/core";
 import * as actionRosCi from "../src/action-ros-ci";
+import * as dep from "../src/dependencies";
 import { execBashCommand } from "../src/action-ros-ci";
 
 jest.setTimeout(20000); // in milliseconds
@@ -37,5 +38,57 @@ describe("validate distribution test", () => {
 		expect(actionRosCi.validateDistros("groovy", "")).toBe(false);
 		expect(actionRosCi.validateDistros("", "bouncy")).toBe(false);
 		expect(actionRosCi.validateDistros("apples", "bananas")).toBe(false);
+	});
+});
+
+describe("PR-specific repos files", () => {
+	it("should not do anything if not a PR", async () => {
+		let payload = {};
+		expect(dep.getReposFilesOverride(payload)).toEqual([]);
+		expect(dep.getReposFilesSupplemental(payload)).toEqual([]);
+		payload = { pull_request: {} };
+		expect(dep.getReposFilesOverride(payload)).toEqual([]);
+		expect(dep.getReposFilesSupplemental(payload)).toEqual([]);
+		payload = { pull_request: { body: "" } };
+		expect(dep.getReposFilesOverride(payload)).toEqual([]);
+		expect(dep.getReposFilesSupplemental(payload)).toEqual([]);
+	});
+
+	it("should extract repos files from the PR body", () => {
+		const bodyEmpty = `
+Description of the changes.
+Blah blah.
+`;
+		let payload = {};
+		payload = { pull_request: { body: bodyEmpty } };
+		expect(dep.getReposFilesOverride(payload)).toEqual([]);
+		expect(dep.getReposFilesSupplemental(payload)).toEqual([]);
+
+		const body = `
+Description of the changes.
+Blah blah.
+
+action-ros-ci-repos-override:   
+action-ros-ci-repos-override: https://raw.githubusercontent.com/ros2/ros2/master/ros2.repos
+action-ros-ci-repos-override : https://some.website.repos
+ action-ros-ci-repos-override:  https://gist.github.com/some-user/some-gist.repos
+ action-ros-ci-repos-supplemental:https://gist.github.com/some-user/some-other-gist.repos
+action-ros-ci-repos-supplemental:  file://path/to/some/file.txt 
+`;
+		payload = { pull_request: { body: body } };
+		const expectedOverride = [
+			"https://raw.githubusercontent.com/ros2/ros2/master/ros2.repos",
+			"https://gist.github.com/some-user/some-gist.repos",
+		];
+		const expectedSupplemental = [
+			"https://gist.github.com/some-user/some-other-gist.repos",
+			"file://path/to/some/file.txt",
+		];
+		expect(dep.getReposFilesOverride(payload)).toEqual(
+			expect.arrayContaining(expectedOverride)
+		);
+		expect(dep.getReposFilesSupplemental(payload)).toEqual(
+			expect.arrayContaining(expectedSupplemental)
+		);
 	});
 });

--- a/src/dependencies.ts
+++ b/src/dependencies.ts
@@ -1,0 +1,79 @@
+import { WebhookPayload } from "@actions/github/lib/interfaces";
+
+// Expecting something like:
+//  action-ros-ci-repos-override: https://raw.githubusercontent.com/ros2/ros2/master/ros2.repos
+const REGEX_REPOS_FILES_OVERRIDE = /action-ros-ci-repos-override:[ ]*([\S]+)/g;
+const REGEX_REPOS_FILES_SUPPLEMENTAL = /action-ros-ci-repos-supplemental:[ ]*([\S]+)/g;
+
+/**
+ * Extract captures of all matches.
+ *
+ * The first dimension contains all the matches and the second
+ * dimension contains the captures for the given match.
+ *
+ * @param content the string in which to search
+ * @param regex the regex to apply
+ * @returns the array of all captures for all matches
+ */
+function extractCaptures(content: string, regex: RegExp): string[][] {
+	const captures: string[][] = [];
+	let matches;
+	while ((matches = regex.exec(content)) !== null) {
+		const capture = matches.slice(1);
+		if (capture.length > 0) {
+			captures.push(capture);
+		}
+	}
+	return captures;
+}
+
+/**
+ * Try to extract PR body from context payload.
+ */
+function extractPrBody(contextPayload: WebhookPayload): string | undefined {
+	const prPayload = contextPayload.pull_request;
+	if (!prPayload) {
+		return undefined;
+	}
+	return prPayload.body;
+}
+
+/**
+ * Get list of repos override files.
+ *
+ * @param contextPayload the github context payload object
+ * @returns an array with all declared repos override files
+ */
+export function getReposFilesOverride(
+	contextPayload: WebhookPayload
+): string[] {
+	const prBody = extractPrBody(contextPayload);
+	if (!prBody) {
+		return [];
+	}
+
+	return extractCaptures(prBody, REGEX_REPOS_FILES_OVERRIDE).map((capture) => {
+		return capture[0];
+	});
+}
+
+/**
+ * Get list of override repos files.
+ *
+ * @param contextPayload the github context payload object
+ * @returns an array with all declared override repos files
+ */
+export function getReposFilesSupplemental(
+	contextPayload: WebhookPayload
+): string[] {
+	const prBody = extractPrBody(contextPayload);
+	if (!prBody) {
+		return [];
+	}
+
+	return extractCaptures(prBody, REGEX_REPOS_FILES_SUPPLEMENTAL).map(
+		(capture) => {
+			return capture[0];
+		}
+	);
+}


### PR DESCRIPTION
Relates to #157

Relates to #490

Similar to ci.ros2.org, this allows declaring PR dependencies by providing:
* repos file(s) to override the one(s) defined through the `vcs-repo-file-url` action input
* supplemental repos file(s) to be used along with the rest

This is done in a PR description, e.g.:

```
action-ros-ci-repos-override : https://gist.github.com/some-user/some.repos
action-ros-ci-repos-override : https://gist.github.com/some-user/some-other.repos
action-ros-ci-repos-supplemental : https://gist.github.com/some-user/some-supplemental.repos
action-ros-ci-repos-supplemental : file://path/to/some/other/supplemental.repos
```

but without the space before the colon (otherwise e2e tests for this PR will try to use those fake links).

To provide some feedback, lists of links of detected overrides/supplemental files are printed in the action output, e.g.:

![Screenshot from 2021-02-06 17-58-43](https://user-images.githubusercontent.com/3717345/107131503-0ce29300-68a5-11eb-8341-d1a75f027074.png)

The feature is currently only tested using unit tests since end-to-end tests are a bit harder for this, but I have tested it and it works great.