### PR TITLE
Enforce prettier code styling

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,4 @@
 # files for tools like prettier and eslint to ignore
 dist
 coverage
+*.md

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -6,7 +6,8 @@
 	},
 	"extends": [
 		"eslint:recommended",
-		"plugin:@typescript-eslint/eslint-recommended"
+		"plugin:@typescript-eslint/eslint-recommended",
+		"plugin:prettier/recommended"
 	],
 	"globals": {
 		"Atomics": "readonly",

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,16 @@ env:
   CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
 jobs:
+  test_lint:
+    name: "Lint sources"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2.1.4
+        with:
+          node-version: "12.x"
+      - run: npm install && npm run lint
+
   test_ros:
     name: "Test ROS package"
     runs-on: ubuntu-latest

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -3,7 +3,11 @@
 ## Build and test
 
 ```
+# install dependencies
 npm install
+# autoformat sources to meet enforced linter style
+npm run fixup
+# generate build artifacts
 npm run build
 ```
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -10957,8 +10957,8 @@ function validateDistros(ros1Distro, ros2Distro) {
 }
 exports.validateDistros = validateDistros;
 /**
-  * Install ROS dependencies for given packages in the workspace, for all ROS distros being used.
-  */
+ * Install ROS dependencies for given packages in the workspace, for all ROS distros being used.
+ */
 function installRosdeps(upToPackages, workspaceDir, ros1Distro, ros2Distro) {
     return __awaiter(this, void 0, void 0, function* () {
         const scriptName = "install_rosdeps.sh";
@@ -10997,7 +10997,10 @@ function run() {
             const extraCmakeArgs = core.getInput("extra-cmake-args");
             const colconExtraArgs = core.getInput("colcon-extra-args");
             const importToken = core.getInput("import-token");
-            const packageNames = core.getInput("package-name", { required: true }).split(RegExp("\\s")).join(" ");
+            const packageNames = core
+                .getInput("package-name", { required: true })
+                .split(RegExp("\\s"))
+                .join(" ");
             const rosWorkspaceName = "ros_ws";
             core.setOutput("ros-workspace-directory-name", rosWorkspaceName);
             const rosWorkspaceDir = path.join(workspace, rosWorkspaceName);

--- a/package-lock.json
+++ b/package-lock.json
@@ -2704,6 +2704,21 @@
 				}
 			}
 		},
+		"eslint-config-prettier": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-7.2.0.tgz",
+			"integrity": "sha512-rV4Qu0C3nfJKPOAhFujFxB7RMP+URFyQqqOZW9DMRD7ZDTFyjaIlETU3xzHELt++4ugC0+Jm084HQYkkJe+Ivg==",
+			"dev": true
+		},
+		"eslint-plugin-prettier": {
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.3.1.tgz",
+			"integrity": "sha512-Rq3jkcFY8RYeQLgk2cCwuc0P7SEFwDravPhsJZOQ5N4YI4DSg50NyqJ/9gdZHzQlHf8MvafSesbNJCcP/FF6pQ==",
+			"dev": true,
+			"requires": {
+				"prettier-linter-helpers": "^1.0.0"
+			}
+		},
 		"eslint-scope": {
 			"version": "5.1.1",
 			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
@@ -3036,6 +3051,12 @@
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
 			"integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA==",
+			"dev": true
+		},
+		"fast-diff": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.2.0.tgz",
+			"integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==",
 			"dev": true
 		},
 		"fast-glob": {
@@ -6515,6 +6536,15 @@
 			"resolved": "https://registry.npmjs.org/prettier/-/prettier-2.2.1.tgz",
 			"integrity": "sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==",
 			"dev": true
+		},
+		"prettier-linter-helpers": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
+			"integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
+			"dev": true,
+			"requires": {
+				"fast-diff": "^1.1.2"
+			}
 		},
 		"pretty-format": {
 			"version": "26.6.2",

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
 	"main": "lib/main.js",
 	"scripts": {
 		"build": "ncc build src/action-ros-ci.ts -o dist",
-		"fixup": "eslint . --fix --ignore-path .lintignore && prettier . --write --ignore-path .lintignore",
-		"lint": "eslint src/action-ros-ci.ts",
+		"fixup": "eslint . --fix",
+		"lint": "eslint .",
 		"test": "tsc --noEmit && jest --coverage"
 	},
 	"repository": {
@@ -44,6 +44,8 @@
 		"@vercel/ncc": "^0.27.0",
 		"acorn": "^8.0.5",
 		"eslint": "^7.18.0",
+		"eslint-config-prettier": "^7.2.0",
+		"eslint-plugin-prettier": "^3.3.1",
 		"husky": "^4.3.5",
 		"jest": "^26.6.3",
 		"jest-circus": "^26.6.3",

--- a/src/action-ros-ci.ts
+++ b/src/action-ros-ci.ts
@@ -6,7 +6,7 @@ import * as io from "@actions/io";
 import * as os from "os";
 import * as path from "path";
 import fs from "fs";
-import retry from "async-retry"
+import retry from "async-retry";
 
 // All command line flags passed to curl when invoked as a command.
 const curlFlagsArray = [
@@ -146,13 +146,13 @@ export function validateDistros(
 }
 
 /**
-  * Install ROS dependencies for given packages in the workspace, for all ROS distros being used.
-  */
+ * Install ROS dependencies for given packages in the workspace, for all ROS distros being used.
+ */
 async function installRosdeps(
 	upToPackages: string,
 	workspaceDir: string,
 	ros1Distro?: string,
-	ros2Distro?: string,
+	ros2Distro?: string
 ): Promise<number> {
 	const scriptName = "install_rosdeps.sh";
 	const scriptPath = path.join(workspaceDir, scriptName);
@@ -168,15 +168,23 @@ async function installRosdeps(
 	# due to difficulty reading names of some non-catkin dependencies in the ros2 core
 	# see https://index.ros.org/doc/ros2/Installation/Foxy/Linux-Development-Setup/#install-dependencies-using-rosdep
 	DEBIAN_FRONTEND=noninteractive RTI_NC_LICENSE_ACCEPTED=yes rosdep install -r --from-paths $package_paths --ignore-src --rosdistro $DISTRO -y || true`;
-	fs.writeFileSync(scriptPath, scriptContent, {mode: 0o766});
+	fs.writeFileSync(scriptPath, scriptContent, { mode: 0o766 });
 
 	let exitCode = 0;
-	const options = {cwd: workspaceDir};
+	const options = { cwd: workspaceDir };
 	if (ros1Distro) {
-		exitCode += await execBashCommand(`./${scriptName} ${ros1Distro}`, "", options);
+		exitCode += await execBashCommand(
+			`./${scriptName} ${ros1Distro}`,
+			"",
+			options
+		);
 	}
 	if (ros2Distro) {
-		exitCode += await execBashCommand(`./${scriptName} ${ros2Distro}`, "", options);
+		exitCode += await execBashCommand(
+			`./${scriptName} ${ros2Distro}`,
+			"",
+			options
+		);
 	}
 	return exitCode;
 }
@@ -191,7 +199,10 @@ async function run() {
 		const extraCmakeArgs = core.getInput("extra-cmake-args");
 		const colconExtraArgs = core.getInput("colcon-extra-args");
 		const importToken = core.getInput("import-token");
-		const packageNames = core.getInput("package-name", { required: true }).split(RegExp("\\s")).join(" ");
+		const packageNames = core
+			.getInput("package-name", { required: true })
+			.split(RegExp("\\s"))
+			.join(" ");
 		const rosWorkspaceName = "ros_ws";
 		core.setOutput("ros-workspace-directory-name", rosWorkspaceName);
 		const rosWorkspaceDir = path.join(workspace, rosWorkspaceName);
@@ -215,11 +226,14 @@ async function run() {
 		// rosdep does not reliably work on Windows, see
 		// ros-infrastructure/rosdep#610 for instance. So, we do not run it.
 		if (!isWindows) {
-			await retry(async () => {
-				await execBashCommand("rosdep update --include-eol-distros");
-			}, {
-				retries: 3,
-			})
+			await retry(
+				async () => {
+					await execBashCommand("rosdep update --include-eol-distros");
+				},
+				{
+					retries: 3,
+				}
+			);
 		}
 
 		// Reset colcon configuration.
@@ -287,7 +301,12 @@ async function run() {
 		// Print HEAD commits of all repos
 		await execBashCommand("vcs log -l1 src/", undefined, options);
 
-		await installRosdeps(packageNames, rosWorkspaceDir, targetRos1Distro, targetRos2Distro);
+		await installRosdeps(
+			packageNames,
+			rosWorkspaceDir,
+			targetRos1Distro,
+			targetRos2Distro
+		);
 
 		if (colconMixinName !== "" && colconMixinRepo !== "") {
 			await execBashCommand(`colcon mixin add default '${colconMixinRepo}'`);


### PR DESCRIPTION
Enforce linter style in the tests and note the autoformatting command in DEVELOPING.md.

Helps avoid the "please don't include formatting changes in functional PRs" comments. I think some people's editors, or maybe some pre-commit hook that I don't have is doing it for other developers.

Helps address comments on #523 and #524

Lint failure in first commit check https://github.com/ros-tooling/action-ros-ci/pull/535/checks?check_run_id=1884593227