### PR TITLE
Fix lint commands in pre-commit hook

### DIFF
--- a/.lintstagedrc.js
+++ b/.lintstagedrc.js
@@ -1,7 +1,7 @@
 module.exports = {
 	"*": [
-		"eslint --cache --fix --ignore-path .lintignore",
-		"prettier --write --ignore-path .lintignore --ignore-unknown",
+		"eslint --cache --fix",
+		"prettier --write --ignore-unknown",
 		// Note: doing the build here ensures we omit unstaged changes
 		() => "npm run build",
 		() => "git add dist/index.js",


### PR DESCRIPTION
The pre-commit hook was failing because `.lintignore` doesn't exist anymore (since #535).