### PR TITLE
Make eslint ignore yaml files

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -2,3 +2,5 @@
 dist
 coverage
 *.md
+*.yml
+*.yaml


### PR DESCRIPTION
eslint doesn't seem to handle yaml files correctly.

The `eslint --cache --fix` command in the pre-commit hook was failing when committing a change to a yaml file:

```
husky > pre-commit (node v12.21.0)
✔ Preparing...
⚠ Running tasks...
  ❯ Running tasks for *
    ✖ eslint --cache --fix [FAILED]
    ◼ prettier --write --ignore-unknown
    ◼ npm run build
    ◼ git add dist/index.js
    ◼ npm run test
↓ Skipped because of errors from tasks. [SKIPPED]
✔ Reverting to original state because of errors...
✔ Cleaning up...

✖ eslint --cache --fix:

/home/chris/action-ros-ci/action.yml
  8:19  error  Parsing error: ';' expected

✖ 1 problem (1 error, 0 warnings)

husky > pre-commit hook failed (add --no-verify to bypass)
```

That doesn't really make sense. So let's just explicitly ignore yaml files for now.