### PR TITLE
Default to empty vcs-repo-file-url

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -176,6 +176,8 @@ jobs:
       matrix:
         os: [macOS-latest, windows-latest, ubuntu-20.04]
         ros_distribution: [foxy, rolling]
+    env:
+      DISTRO_REPOS_URL: "https://raw.githubusercontent.com/ros2/ros2/${{ matrix.ros_distribution == 'rolling' && 'master' || matrix.ros_distribution }}/ros2.repos"
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2.1.4
@@ -189,6 +191,7 @@ jobs:
         with:
           package-name: ament_copyright
           target-ros2-distro: ${{ matrix.ros_distribution }}
+          vcs-repo-file-url: ${{ env.DISTRO_REPOS_URL }}
       - run: test -d "${{ steps.test_single_package.outputs.ros-workspace-directory-name }}/install/ament_copyright"
         name: "Check that ament_copyright install directory is present"
 
@@ -198,6 +201,7 @@ jobs:
         with:
           package-name: ament_copyright ament_lint
           target-ros2-distro: ${{ matrix.ros_distribution }}
+          vcs-repo-file-url: ${{ env.DISTRO_REPOS_URL }}
       - run: test -d "${{ steps.test_multiple_packages.outputs.ros-workspace-directory-name }}/install/ament_copyright"
         name: "Check that ament_copyright install directory is present"
       - run: test -d "${{ steps.test_multiple_packages.outputs.ros-workspace-directory-name }}/install/ament_lint"
@@ -210,6 +214,7 @@ jobs:
         with:
           package-name: rmw_implementation
           target-ros2-distro: ${{ matrix.ros_distribution }}
+          vcs-repo-file-url: ${{ env.DISTRO_REPOS_URL }}
       - run: test -d "${{ steps.test_connext_dependency.outputs.ros-workspace-directory-name }}/install/rmw_implementation"
         name: "Check that rmw_implementation install directory is present"
         if: matrix.os == 'ubuntu-20.04'
@@ -222,6 +227,7 @@ jobs:
           colcon-mixin-repository: https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml
           package-name: ament_copyright
           target-ros2-distro: ${{ matrix.ros_distribution }}
+          vcs-repo-file-url: ${{ env.DISTRO_REPOS_URL }}
       - run: test -d "${{ steps.test_mixin.outputs.ros-workspace-directory-name }}/install/ament_copyright"
         name: "Check that ament_copyright install directory is present"
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The action first assembles a workspace, then runs `colcon build`, and `colcon te
 
 The workspace is built by running:
 
-- `vcs import` on the repo file specified through the `vcs-repo-file-url` argument (defaults to `https://raw.githubusercontent.com/ros2/ros2/master/ros2.repos`).
+- `vcs import` on the repo file(s) specified through the `vcs-repo-file-url` argument, if any (defaults to none)
 - checkout the code under test in the workspace using `vcs`
 - `rosdep install` for the workspace, to get its dependencies
 - run `colcon build` for all packages specified in `package-name`
@@ -64,6 +64,7 @@ steps:
     with:
       package-name: ament_copyright
       target-ros2-distro: foxy
+      vcs-repo-file-url: https://raw.githubusercontent.com/ros2/ros2/foxy/ros2.repos
 ```
 
 ### Build with a custom `repos` or `rosinstall` file
@@ -101,7 +102,6 @@ steps:
     with:
       package-name: my_package
       target-ros1-distro: melodic
-      vcs-repo-file-url: ""
 ```
 
 ### Enable Address Sanitizer to automatically report memory issues
@@ -112,6 +112,8 @@ memory corruption bugs.
 ```yaml
 steps:
   - uses: ros-tooling/setup-ros@v0.1
+    with:
+      required-ros-distributions: foxy
   - uses: ros-tooling/action-ros-ci@v0.1
     with:
       colcon-mixin-name: asan
@@ -142,6 +144,8 @@ preferable to use a `colcon` mixin to pass the appropriate flags automatically.
 ```yaml
 steps:
   - uses: ros-tooling/setup-ros@v0.1
+    with:
+      required-ros-distributions: foxy
   - uses: ros-tooling/action-ros-ci@v0.1
     with:
       package-name: my_package
@@ -164,6 +168,8 @@ preferable to use a `colcon` mixin to pass the appropriate flags automatically.
 ```yaml
 steps:
   - uses: ros-tooling/setup-ros@v0.1
+    with:
+      required-ros-distributions: foxy
   - uses: ros-tooling/action-ros-ci@v0.1
     with:
       package-name: my_package
@@ -184,6 +190,8 @@ See [action/codecov-action](https://github.com/codecov/codecov-action) documenta
 ```yaml
 steps:
   - uses: ros-tooling/setup-ros@v0.1
+    with:
+      required-ros-distributions: foxy
   - uses: ros-tooling/action-ros-ci@v0.1
     with:
       package-name: my_package

--- a/action.yml
+++ b/action.yml
@@ -59,9 +59,11 @@ inputs:
     required: false
   vcs-repo-file-url:
     description: |
-      repo file URL passed to vcs to initialize the colcon workspace.
-      The URL may point to a local file, such as file://path/to/file.txt
-    default: "https://raw.githubusercontent.com/ros2/ros2/master/ros2.repos"
+      Repo file URL passed to vcs to initialize the colcon workspace.
+      The URL may point to a local file, such as file://path/to/file.txt.
+      For example, for ROS 2 Rolling source repositories, use:
+      https://raw.githubusercontent.com/ros2/ros2/master/ros2.repos
+    default: ""
 outputs:
   ros-workspace-directory-name:
     description: |


### PR DESCRIPTION
Fixes #561

This changes the default value for the `vcs-repo-file-url` input to an empty
string. Therefore, by default, action-ros-ci will rely on binaries
(e.g. installed by setup-ros) for any dependencies.

Signed-off-by: Christophe Bedard <bedard.christophe@gmail.com>