### PR TITLE
Explicitly provide .eslintignore to eslint & prettier

### DIFF
--- a/.lintstagedrc.js
+++ b/.lintstagedrc.js
@@ -1,7 +1,7 @@
 module.exports = {
 	"*": [
-		"eslint --cache --fix",
-		"prettier --write --ignore-unknown",
+		"eslint --cache --fix --ignore-path .eslintignore",
+		"prettier --write --ignore-path .eslintignore --ignore-unknown",
 		// Note: doing the build here ensures we omit unstaged changes
 		() => "npm run build",
 		() => "git add dist/index.js",


### PR DESCRIPTION
Follow-up to #564

eslint does consider `.eslintignore` by default, but prettier does not (it uses `.prettierignore` instead). My bad.

Let's just roll back to explicitly providing the (right) file!