### PR TITLE
Add colcon-defaults input

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -240,6 +240,21 @@ jobs:
           target-ros2-distro: ${{ matrix.ros_distribution }}
       - run: test -d "${{ steps.test_repo.outputs.ros-workspace-directory-name }}/install/ament_copyright"
 
+      - uses: ./
+        id: test_colcon_defaults
+        name: "Test single package, with colcon defaults"
+        with:
+          colcon-defaults: |
+            {
+              "build": {
+                "build-base": "build-custom"
+              }
+            }
+          package-name: ament_copyright
+          target-ros2-distro: ${{ matrix.ros_distribution }}
+      - run: test -d "${{ steps.test_colcon_defaults.outputs.ros-workspace-directory-name }}/install/ament_copyright"
+      - run: test -d "${{ steps.test_colcon_defaults.outputs.ros-workspace-directory-name }}/build-custom"
+
       # The second repo file is ignored, but will get vcs-import'ed anyway.
       # This test case just run basic testing on the action logic, making
       # sure the for-loop is implemented correctly.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -252,6 +252,7 @@ jobs:
             }
           package-name: ament_copyright
           target-ros2-distro: ${{ matrix.ros_distribution }}
+          vcs-repo-file-url: ${{ env.DISTRO_REPOS_URL }}
       - run: test -d "${{ steps.test_colcon_defaults.outputs.ros-workspace-directory-name }}/install/ament_copyright"
       - run: test -d "${{ steps.test_colcon_defaults.outputs.ros-workspace-directory-name }}/build-custom"
 

--- a/README.md
+++ b/README.md
@@ -104,6 +104,28 @@ steps:
       target-ros1-distro: melodic
 ```
 
+### Use a `colcon` `defaults.yaml` file
+
+To use a [`colcon` `defaults.yaml` file](https://colcon.readthedocs.io/en/released/user/configuration.html#defaults-yaml), provide a valid JSON string through the `colcon-defaults` input.
+This allows using a `colcon` option/argument that is not exposed by this action's inputs.
+
+```yaml
+steps:
+  - uses: ros-tooling/setup-ros@v0.1
+  - uses: ros-tooling/action-ros-ci@v0.1
+    with:
+      package-name: my_package
+      target-ros2-distro: foxy
+      colcon-defaults: |
+        {
+          "build": {
+            "cmake-args": [
+                "-DMY_CUSTOM_OPTION=ON"
+            ]
+          }
+        }
+```
+
 ### Enable Address Sanitizer to automatically report memory issues
 
 [ASan][addresssanitizer] is an open-source tool developed to automatically report

--- a/README.md
+++ b/README.md
@@ -112,6 +112,8 @@ This allows using a `colcon` option/argument that is not exposed by this action'
 ```yaml
 steps:
   - uses: ros-tooling/setup-ros@v0.1
+    with:
+      required-ros-distributions: foxy
   - uses: ros-tooling/action-ros-ci@v0.1
     with:
       package-name: my_package

--- a/action.yml
+++ b/action.yml
@@ -5,6 +5,13 @@ branding:
   icon: "activity"
   color: "gray-dark"
 inputs:
+  colcon-defaults:
+    default: ""
+    description: |
+      Valid JSON content to use as a colcon defaults.yaml file.
+      Use a pipe to provide a multiline string.
+      See: https://colcon.readthedocs.io/en/released/user/configuration.html#defaults-yaml
+    required: false
   colcon-mixin-name:
     default: ""
     description: "Colcon mixin to be used to compile and test (empty means no mixin)"

--- a/dist/index.js
+++ b/dist/index.js
@@ -10875,6 +10875,21 @@ const targetROS2DistroInput = "target-ros2-distro";
 const isLinux = process.platform == "linux";
 const isWindows = process.platform == "win32";
 /**
+ * Check if a string is a valid JSON string.
+ *
+ * @param str the string to validate
+ * @returns `true` if valid, `false` otherwise
+ */
+function isValidJson(str) {
+    try {
+        JSON.parse(str);
+    }
+    catch (e) {
+        return false;
+    }
+    return true;
+}
+/**
  * Convert local paths to URLs.
  *
  * The user can pass the VCS repo file either as a URL or a path.
@@ -10993,6 +11008,7 @@ function run() {
         try {
             const repo = github.context.repo;
             const workspace = process.env.GITHUB_WORKSPACE;
+            const colconDefaults = core.getInput("colcon-defaults");
             const colconMixinName = core.getInput("colcon-mixin-name");
             const colconMixinRepo = core.getInput("colcon-mixin-repository");
             const extraCmakeArgs = core.getInput("extra-cmake-args");
@@ -11045,8 +11061,17 @@ function run() {
                     retries: 3,
                 });
             }
-            // Reset colcon configuration.
-            yield io.rmRF(path.join(os.homedir(), ".colcon"));
+            // Reset colcon configuration and create defaults file if one was provided.
+            const colconHome = path.join(os.homedir(), ".colcon");
+            yield io.rmRF(colconHome);
+            if (colconDefaults.length > 0) {
+                if (!isValidJson(colconDefaults)) {
+                    core.setFailed(`colcon-defaults value is not a valid JSON string:\n${colconDefaults}`);
+                    return;
+                }
+                yield io.mkdirP(colconHome);
+                fs_1.default.writeFileSync(path.join(colconHome, "defaults.yaml"), colconDefaults);
+            }
             // Wipe out the workspace directory to ensure the workspace is always
             // identical.
             yield io.rmRF(rosWorkspaceDir);

--- a/src/action-ros-ci.ts
+++ b/src/action-ros-ci.ts
@@ -285,8 +285,8 @@ async function run() {
 		}
 
 		// Reset colcon configuration and create defaults file if one was provided.
-		const colconHome = path.join(os.homedir(), ".colcon");
-		await io.rmRF(colconHome);
+		await io.rmRF(path.join(os.homedir(), ".colcon"));
+		let colconDefaultsFile = "";
 		if (colconDefaults.length > 0) {
 			if (!isValidJson(colconDefaults)) {
 				core.setFailed(
@@ -294,8 +294,11 @@ async function run() {
 				);
 				return;
 			}
-			await io.mkdirP(colconHome);
-			fs.writeFileSync(path.join(colconHome, "defaults.yaml"), colconDefaults);
+			colconDefaultsFile = path.join(
+				fs.mkdtempSync(path.join(os.tmpdir(), "colcon-defaults-")),
+				"defaults.yaml"
+			);
+			fs.writeFileSync(colconDefaultsFile, colconDefaults);
 		}
 
 		// Wipe out the workspace directory to ensure the workspace is always
@@ -314,9 +317,14 @@ async function run() {
 			fs.appendFileSync(path.join(os.homedir(), ".gitconfig"), config);
 		}
 
-		const options = {
+		const options: im.ExecOptions = {
 			cwd: rosWorkspaceDir,
 		};
+		if (colconDefaultsFile !== "") {
+			options.env = {
+				COLCON_DEFAULTS_FILE: colconDefaultsFile,
+			};
+		}
 
 		const curlFlags = curlFlagsArray.join(" ");
 		for (const vcsRepoFileUrl of vcsRepoFileUrlListResolved) {
@@ -373,8 +381,12 @@ async function run() {
 		);
 
 		if (colconMixinName !== "" && colconMixinRepo !== "") {
-			await execBashCommand(`colcon mixin add default '${colconMixinRepo}'`);
-			await execBashCommand("colcon mixin update default");
+			await execBashCommand(
+				`colcon mixin add default '${colconMixinRepo}'`,
+				undefined,
+				options
+			);
+			await execBashCommand("colcon mixin update default", undefined, options);
 		}
 
 		let extra_options: string[] = [];
@@ -441,7 +453,7 @@ async function run() {
 		// data fail the build.
 		const colconLcovInitialCmd = "colcon lcov-result --initial";
 		await execBashCommand(colconLcovInitialCmd, colconCommandPrefix, {
-			cwd: rosWorkspaceDir,
+			...options,
 			ignoreReturnCode: true,
 		});
 
@@ -462,7 +474,7 @@ async function run() {
 			`--packages-select ${packageNames}`,
 		].join(" ");
 		await execBashCommand(colconLcovResultCmd, colconCommandPrefix, {
-			cwd: rosWorkspaceDir,
+			...options,
 			ignoreReturnCode: true,
 		});
 


### PR DESCRIPTION
Relates to #525, #526, #555

This adds a `colcon-defaults` input. The JSON content is validated and then written to `~/.colcon/defaults.yaml`.

Signed-off-by: Christophe Bedard <bedard.christophe@gmail.com>