### PR TITLE
Use --verbose option for {lcov,coveragepy}-result

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -11206,11 +11206,14 @@ function run() {
                 `colcon lcov-result`,
                 `--filter ${coverageIgnorePattern}`,
                 `--packages-select ${packageNames}`,
+                `--verbose`,
             ].join(" ");
             yield execBashCommand(colconLcovResultCmd, colconCommandPrefix, Object.assign(Object.assign({}, options), { ignoreReturnCode: true }));
             const colconCoveragepyResultCmd = [
                 `colcon coveragepy-result`,
                 `--packages-select ${packageNames}`,
+                `--verbose`,
+                `--coverage-report-args -m`,
             ].join(" ");
             yield execBashCommand(colconCoveragepyResultCmd, colconCommandPrefix, options);
             core.setOutput("ros-workspace-directory-name", rosWorkspaceName);

--- a/src/action-ros-ci.ts
+++ b/src/action-ros-ci.ts
@@ -472,6 +472,7 @@ async function run() {
 			`colcon lcov-result`,
 			`--filter ${coverageIgnorePattern}`,
 			`--packages-select ${packageNames}`,
+			`--verbose`,
 		].join(" ");
 		await execBashCommand(colconLcovResultCmd, colconCommandPrefix, {
 			...options,
@@ -481,6 +482,8 @@ async function run() {
 		const colconCoveragepyResultCmd = [
 			`colcon coveragepy-result`,
 			`--packages-select ${packageNames}`,
+			`--verbose`,
+			`--coverage-report-args -m`,
 		].join(" ");
 		await execBashCommand(
 			colconCoveragepyResultCmd,


### PR DESCRIPTION
This adds the `--verbose` flag for `colcon lcov-result` (i.e. short coverage report for each package) and `--verbose --coverage-report-args -m` flags for `colcon coveragepy-result` (i.e. coverage report for each package and global coverage report, including uncovered lines).

The goal is to display generated coverage information (if any) directly in CI without *needing* to use services like codecov.

See:

* https://github.com/colcon/colcon-lcov-result#tips-and-tricks
* https://github.com/colcon/colcon-coveragepy-result#options

Signed-off-by: Christophe Bedard <bedard.christophe@gmail.com>