### PR TITLE
Remove --pytest-with-coverage option from default colcon test command

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -11195,7 +11195,6 @@ function run() {
             const colconTestCmd = [
                 `colcon test`,
                 `--event-handlers console_cohesion+`,
-                `--pytest-with-coverage`,
                 `--return-code-on-test-failure`,
                 `--packages-select ${packageNames}`,
                 `${extra_options.join(" ")}`,

--- a/src/action-ros-ci.ts
+++ b/src/action-ros-ci.ts
@@ -460,7 +460,6 @@ async function run() {
 		const colconTestCmd = [
 			`colcon test`,
 			`--event-handlers console_cohesion+`,
-			`--pytest-with-coverage`,
 			`--return-code-on-test-failure`,
 			`--packages-select ${packageNames}`,
 			`${extra_options.join(" ")}`,


### PR DESCRIPTION
It was originally added in #109 to avoid hardcoding the pytest coverage options. However, instead of using this option by default, users can simply use the `coverage-pytest` test mixin explicitly if they want to: https://github.com/colcon/colcon-mixin-repository/blob/1ddb69bedfd1f04c2f000e95452f7c24a4d6176b/coverage.mixin#L14

Signed-off-by: Christophe Bedard <bedard.christophe@gmail.com>