### PR TITLE
Don't run scheduled jobs on forks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,11 +17,17 @@ env:
   CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
 jobs:
+  pre_condition:
+    name: "Don't run scheduled jobs on forks"
+    runs-on: ubuntu-latest
+    if: ${{ (github.event_name != 'schedule') || (github.event_name == 'schedule' && github.repository == 'ros-tooling/action-ros-ci') }}
+    steps:
+      - run: 'true'
+
   test_lint:
     name: "Lint sources"
-    # Don't run scheduled jobs on forks
-    if: ${{ (github.event_name != 'schedule') || (github.event_name == 'schedule' && github.repository == 'ros-tooling/action-ros-ci') }}
     runs-on: ubuntu-latest
+    needs: pre_condition
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2.1.4
@@ -31,9 +37,8 @@ jobs:
 
   test_ros:
     name: "Test ROS package"
-    # Don't run scheduled jobs on forks
-    if: ${{ (github.event_name != 'schedule') || (github.event_name == 'schedule' && github.repository == 'ros-tooling/action-ros-ci') }}
     runs-on: ubuntu-latest
+    needs: pre_condition
     strategy:
       fail-fast: false
       matrix:
@@ -74,9 +79,8 @@ jobs:
 
   test_ros2:
     name: "Test ROS 2"
-    # Don't run scheduled jobs on forks
-    if: ${{ (github.event_name != 'schedule') || (github.event_name == 'schedule' && github.repository == 'ros-tooling/action-ros-ci') }}
     runs-on: ${{ matrix.os }}
+    needs: pre_condition
     strategy:
       fail-fast: false
       matrix:
@@ -106,9 +110,8 @@ jobs:
 
   test_ros2_foxy_package_with_dependencies:
     name: "Test ROS 2 foxy package with ROS dependencies"
-    # Don't run scheduled jobs on forks
-    if: ${{ (github.event_name != 'schedule') || (github.event_name == 'schedule' && github.repository == 'ros-tooling/action-ros-ci') }}
     runs-on: ubuntu-20.04
+    needs: pre_condition
     steps:
       - uses: actions/checkout@v2
       - uses: ros-tooling/setup-ros@0.1.2
@@ -122,9 +125,8 @@ jobs:
 
   test_ros2_docker:
     name: "ROS 2 Docker"
-    # Don't run scheduled jobs on forks
-    if: ${{ (github.event_name != 'schedule') || (github.event_name == 'schedule' && github.repository == 'ros-tooling/action-ros-ci') }}
     runs-on: ubuntu-latest
+    needs: pre_condition
     strategy:
       fail-fast: false
       matrix:
@@ -180,9 +182,8 @@ jobs:
 
   test_ros2_from_source:
     name: "ROS 2 from source"
-    # Don't run scheduled jobs on forks
-    if: ${{ (github.event_name != 'schedule') || (github.event_name == 'schedule' && github.repository == 'ros-tooling/action-ros-ci') }}
     runs-on: ${{ matrix.os }}
+    needs: pre_condition
     strategy:
       fail-fast: false
       matrix:
@@ -317,9 +318,8 @@ jobs:
 
   test_ros2_from_source_docker:
     name: "Test ROS 2 from source Docker"
-    # Don't run scheduled jobs on forks
-    if: ${{ (github.event_name != 'schedule') || (github.event_name == 'schedule' && github.repository == 'ros-tooling/action-ros-ci') }}
     runs-on: ubuntu-latest
+    needs: pre_condition
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,8 @@ env:
 jobs:
   test_lint:
     name: "Lint sources"
+    # Don't run scheduled jobs on forks
+    if: ${{ (github.event_name != 'schedule') || (github.event_name == 'schedule' && github.repository == 'ros-tooling/action-ros-ci') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -29,6 +31,8 @@ jobs:
 
   test_ros:
     name: "Test ROS package"
+    # Don't run scheduled jobs on forks
+    if: ${{ (github.event_name != 'schedule') || (github.event_name == 'schedule' && github.repository == 'ros-tooling/action-ros-ci') }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -70,6 +74,8 @@ jobs:
 
   test_ros2:
     name: "Test ROS 2"
+    # Don't run scheduled jobs on forks
+    if: ${{ (github.event_name != 'schedule') || (github.event_name == 'schedule' && github.repository == 'ros-tooling/action-ros-ci') }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -100,6 +106,8 @@ jobs:
 
   test_ros2_foxy_package_with_dependencies:
     name: "Test ROS 2 foxy package with ROS dependencies"
+    # Don't run scheduled jobs on forks
+    if: ${{ (github.event_name != 'schedule') || (github.event_name == 'schedule' && github.repository == 'ros-tooling/action-ros-ci') }}
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
@@ -114,6 +122,8 @@ jobs:
 
   test_ros2_docker:
     name: "ROS 2 Docker"
+    # Don't run scheduled jobs on forks
+    if: ${{ (github.event_name != 'schedule') || (github.event_name == 'schedule' && github.repository == 'ros-tooling/action-ros-ci') }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -170,6 +180,8 @@ jobs:
 
   test_ros2_from_source:
     name: "ROS 2 from source"
+    # Don't run scheduled jobs on forks
+    if: ${{ (github.event_name != 'schedule') || (github.event_name == 'schedule' && github.repository == 'ros-tooling/action-ros-ci') }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -305,6 +317,8 @@ jobs:
 
   test_ros2_from_source_docker:
     name: "Test ROS 2 from source Docker"
+    # Don't run scheduled jobs on forks
+    if: ${{ (github.event_name != 'schedule') || (github.event_name == 'schedule' && github.repository == 'ros-tooling/action-ros-ci') }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false


### PR DESCRIPTION
I often enable actions on my fork to open PRs (on my own fork) to test things out with CI. There's no real reason to run hourly scheduled jobs on forks.

I tried these and they didn't work:

* `if: ${{ (github.event_name != 'schedule') || (github.event_name == 'schedule' && !github.event.repository.fork) }}`
* `if: ${{ (github.event_name != 'schedule') || (github.event_name == 'schedule' && github.event.repository.fork == false) }}`