### PR TITLE
Remove colcon-mixin-name

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -236,7 +236,12 @@ jobs:
         id: test_mixin
         name: "Test single package, with custom mixin"
         with:
-          colcon-mixin-name: asan
+          colcon-defaults: |
+            {
+              "build": {
+                "mixin": ["asan-gcc"]
+              }
+            }
           colcon-mixin-repository: https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml
           package-name: ament_copyright
           target-ros2-distro: ${{ matrix.ros_distribution }}
@@ -289,7 +294,12 @@ jobs:
         id: test_coverage
         name: "Test single package, with coverage enabled (Linux only)"
         with:
-          colcon-mixin-name: coverage-gcc
+          colcon-defaults: |
+            {
+              "build": {
+                "mixin": ["coverage-gcc"]
+              }
+            }
           colcon-mixin-repository: https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml
           package-name: osrf_testing_tools_cpp
           target-ros2-distro: ${{ matrix.ros_distribution }}
@@ -391,7 +401,12 @@ jobs:
         id: test_mixin
         name: "Test single package, with custom mixin"
         with:
-          colcon-mixin-name: asan
+          colcon-defaults: |
+            {
+              "build": {
+                "mixin": ["asan-gcc"]
+              }
+            }
           colcon-mixin-repository: https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml
           package-name: ament_copyright
           target-ros2-distro: ${{ matrix.ros_distribution }}
@@ -428,7 +443,12 @@ jobs:
         id: test_coverage
         name: "Test single package, with coverage enabled (Linux only)"
         with:
-          colcon-mixin-name: coverage-gcc
+          colcon-defaults: |
+            {
+              "build": {
+                "mixin": ["coverage-gcc"]
+              }
+            }
           colcon-mixin-repository: https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml
           package-name: osrf_testing_tools_cpp
           target-ros2-distro: ${{ matrix.ros_distribution }}

--- a/README.md
+++ b/README.md
@@ -176,7 +176,12 @@ steps:
       required-ros-distributions: foxy
   - uses: ros-tooling/action-ros-ci@v0.1
     with:
-      colcon-mixin-name: asan
+      colcon-defaults: |
+        {
+          "build": {
+            "mixin": ["asan-gcc"]
+          }
+        }
       colcon-mixin-repository: https://raw.githubusercontent.com/colcon/colcon-mixin-repository/3e627e0fa30db85aea05a50e2c61a9832664d236/index.yaml
       package-name: my_package
       target-ros2-distro: foxy
@@ -194,12 +199,11 @@ ASan is analyzing memory issues at runtime. ASan diagnostic messages will be emi
 
 #### Generate code coverage information using `lcov` and `colcon-lcov-result`
 
-If the compiler is invoked with the appropriate flags, `action-ros-ci` will use
-[`colcon-lcov-result`](https://github.com/colcon/colcon-lcov-result) to generate
-coverage information.
+Generate code coverage information for C/C++ files using the appropriate mixins for `gcc`.
+`action-ros-ci` uses [`colcon-lcov-result`](https://github.com/colcon/colcon-lcov-result) to aggregate generated coverage information.
 
 Flags can be passed manually using, for instance, `extra-cmake-args`, but it is
-preferable to use a `colcon` mixin to pass the appropriate flags automatically.
+preferable to use a `colcon` mixin (through [`colcon-defaults`](#Use-a-colcon-defaultsyaml-file)) to pass the appropriate flags automatically.
 
 ```yaml
 steps:
@@ -210,7 +214,12 @@ steps:
     with:
       package-name: my_package
       target-ros2-distro: foxy
-      colcon-mixin-name: coverage-gcc
+      colcon-defaults: |
+        {
+          "build": {
+            "mixin": ["coverage-gcc"]
+          }
+        }
       # If possible, pin the repository in the workflow to a specific commit to avoid
       # changes in colcon-mixin-repository from breaking your tests.
       colcon-mixin-repository: https://raw.githubusercontent.com/colcon/colcon-mixin-repository/1ddb69bedfd1f04c2f000e95452f7c24a4d6176b/index.yaml
@@ -218,12 +227,8 @@ steps:
 
 #### Generate code coverage information using `coveragepy` and `colcon-coveragepy-result`
 
-If `colcon` is invoked with the `coverage-pytest` mixin, `action-ros-ci` will use
-[`colcon-coveragepy-result`](https://github.com/colcon/colcon-coveragepy-result) to generate
-coverage information.
-
-Flags can be passed manually using, for instance, `extra-cmake-args`, but it is
-preferable to use a `colcon` mixin to pass the appropriate flags automatically.
+Generate code coverage information for Python files using the appropriate mixins.
+`action-ros-ci` uses [`colcon-coveragepy-result`](https://github.com/colcon/colcon-coveragepy-result) to aggregate generated coverage information.
 
 ```yaml
 steps:
@@ -234,7 +239,15 @@ steps:
     with:
       package-name: my_package
       target-ros2-distro: foxy
-      colcon-mixin-name: coverage-pytest
+      colcon-defaults: |
+        {
+          "build": {
+            "mixin": ["coverage-pytest"]
+          },
+          "test": {
+            "mixin": ["coverage-pytest"]
+          }
+        }
       # If possible, pin the repository in the workflow to a specific commit to avoid
       # changes in colcon-mixin-repository from breaking your tests.
       colcon-mixin-repository: https://raw.githubusercontent.com/colcon/colcon-mixin-repository/1ddb69bedfd1f04c2f000e95452f7c24a4d6176b/index.yaml
@@ -257,7 +270,15 @@ steps:
     with:
       package-name: my_package
       target-ros2-distro: foxy
-      colcon-mixin-name: coverage-gcc coverage-pytest
+      colcon-defaults: |
+        {
+          "build": {
+            "mixin": ["coverage-gcc", "coverage-pytest"]
+          },
+          "test": {
+            "mixin": ["coverage-pytest"]
+          }
+        }
       # If possible, pin the repository in the workflow to a specific commit to avoid
       # changes in colcon-mixin-repository from breaking your tests.
       colcon-mixin-repository: https://raw.githubusercontent.com/colcon/colcon-mixin-repository/1ddb69bedfd1f04c2f000e95452f7c24a4d6176b/index.yaml

--- a/action.yml
+++ b/action.yml
@@ -12,13 +12,9 @@ inputs:
       Use a pipe to provide a multiline string.
       See: https://colcon.readthedocs.io/en/released/user/configuration.html#defaults-yaml
     required: false
-  colcon-mixin-name:
-    default: ""
-    description: "Colcon mixin to be used to compile and test (empty means no mixin)"
-    required: false
   colcon-mixin-repository:
     default: "https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml"
-    description: "Mixin repository containing the mixin specified in colcon-mixin-name"
+    description: "Mixin repository containing the mixin(s) specified through colcon-defaults or colcon-extra-args"
     required: false
   coverage-ignore-pattern:
     description: |
@@ -33,7 +29,7 @@ inputs:
   colcon-extra-args:
     default: ""
     description: |
-      Arbitrary space-separated additional flags to pass to colcon.
+      Arbitrary space-separated additional flags to pass to colcon (build & test).
     required: false
   import-token:
     default: ""

--- a/dist/index.js
+++ b/dist/index.js
@@ -11091,9 +11091,7 @@ function run() {
                 cwd: rosWorkspaceDir,
             };
             if (colconDefaultsFile !== "") {
-                options.env = {
-                    COLCON_DEFAULTS_FILE: colconDefaultsFile,
-                };
+                options.env = Object.assign(Object.assign({}, process.env), { COLCON_DEFAULTS_FILE: colconDefaultsFile });
             }
             // Make sure to delete root .colcon directory if it exists
             // This is because, for some reason, using Docker, commands might get run as root

--- a/dist/index.js
+++ b/dist/index.js
@@ -10949,6 +10949,9 @@ function execBashCommand(commandLine, commandPrefix, options, log_message) {
             toolRunnerCommandLineArgs = ["-c", bashScript];
         }
         const runner = new tr.ToolRunner(toolRunnerCommandLine, toolRunnerCommandLineArgs, options);
+        if (options && options.silent) {
+            return runner.exec();
+        }
         return core.group(message, () => {
             return runner.exec();
         });
@@ -11092,6 +11095,9 @@ function run() {
                     COLCON_DEFAULTS_FILE: colconDefaultsFile,
                 };
             }
+            // Make sure to delete root .colcon directory if it exists
+            // This is because, for some reason, using Docker, commands might get run as root
+            yield execBashCommand(`rm -rf ${path.join(path.sep, "root", ".colcon")} || true`, undefined, Object.assign(Object.assign({}, options), { silent: true }));
             const curlFlags = curlFlagsArray.join(" ");
             for (const vcsRepoFileUrl of vcsRepoFileUrlListResolved) {
                 yield execBashCommand(`curl ${curlFlags} '${vcsRepoFileUrl}' | vcs import --force --recursive src/`, undefined, options);

--- a/dist/index.js
+++ b/dist/index.js
@@ -11009,7 +11009,6 @@ function run() {
             const repo = github.context.repo;
             const workspace = process.env.GITHUB_WORKSPACE;
             const colconDefaults = core.getInput("colcon-defaults");
-            const colconMixinName = core.getInput("colcon-mixin-name");
             const colconMixinRepo = core.getInput("colcon-mixin-repository");
             const extraCmakeArgs = core.getInput("extra-cmake-args");
             const colconExtraArgs = core.getInput("colcon-extra-args");
@@ -11142,14 +11141,11 @@ done`;
             // Print HEAD commits of all repos
             yield execBashCommand("vcs log -l1 src/", undefined, options);
             yield installRosdeps(packageNames, rosWorkspaceDir, targetRos1Distro, targetRos2Distro);
-            if (colconMixinName !== "" && colconMixinRepo !== "") {
+            if (colconDefaults.includes(`"mixin"`) && colconMixinRepo !== "") {
                 yield execBashCommand(`colcon mixin add default '${colconMixinRepo}'`, undefined, options);
                 yield execBashCommand("colcon mixin update default", undefined, options);
             }
             let extra_options = [];
-            if (colconMixinName !== "") {
-                extra_options = extra_options.concat(["--mixin", colconMixinName]);
-            }
             if (colconExtraArgs !== "") {
                 extra_options = extra_options.concat(colconExtraArgs);
             }
@@ -11197,7 +11193,7 @@ done`;
                 `--event-handlers console_cohesion+`,
                 `--packages-up-to ${packageNames}`,
                 `${extra_options.join(" ")}`,
-                `--cmake-args ${extraCmakeArgs}`,
+                extraCmakeArgs !== "" ? `--cmake-args ${extraCmakeArgs}` : "",
             ].join(" ");
             if (!isWindows) {
                 colconBuildCmd = colconBuildCmd.concat(" --symlink-install");

--- a/src/action-ros-ci.ts
+++ b/src/action-ros-ci.ts
@@ -211,7 +211,6 @@ async function run() {
 		const workspace = process.env.GITHUB_WORKSPACE as string;
 
 		const colconDefaults = core.getInput("colcon-defaults");
-		const colconMixinName = core.getInput("colcon-mixin-name");
 		const colconMixinRepo = core.getInput("colcon-mixin-repository");
 		const extraCmakeArgs = core.getInput("extra-cmake-args");
 		const colconExtraArgs = core.getInput("colcon-extra-args");
@@ -395,7 +394,7 @@ done`;
 			targetRos2Distro
 		);
 
-		if (colconMixinName !== "" && colconMixinRepo !== "") {
+		if (colconDefaults.includes(`"mixin"`) && colconMixinRepo !== "") {
 			await execBashCommand(
 				`colcon mixin add default '${colconMixinRepo}'`,
 				undefined,
@@ -405,9 +404,6 @@ done`;
 		}
 
 		let extra_options: string[] = [];
-		if (colconMixinName !== "") {
-			extra_options = extra_options.concat(["--mixin", colconMixinName]);
-		}
 		if (colconExtraArgs !== "") {
 			extra_options = extra_options.concat(colconExtraArgs);
 		}
@@ -457,7 +453,7 @@ done`;
 			`--event-handlers console_cohesion+`,
 			`--packages-up-to ${packageNames}`,
 			`${extra_options.join(" ")}`,
-			`--cmake-args ${extraCmakeArgs}`,
+			extraCmakeArgs !== "" ? `--cmake-args ${extraCmakeArgs}` : "",
 		].join(" ");
 		if (!isWindows) {
 			colconBuildCmd = colconBuildCmd.concat(" --symlink-install");

--- a/src/action-ros-ci.ts
+++ b/src/action-ros-ci.ts
@@ -324,6 +324,7 @@ async function run() {
 		};
 		if (colconDefaultsFile !== "") {
 			options.env = {
+				...process.env,
 				COLCON_DEFAULTS_FILE: colconDefaultsFile,
 			};
 		}

--- a/src/action-ros-ci.ts
+++ b/src/action-ros-ci.ts
@@ -130,6 +130,9 @@ export async function execBashCommand(
 		toolRunnerCommandLineArgs,
 		options
 	);
+	if (options && options.silent) {
+		return runner.exec();
+	}
 	return core.group(message, () => {
 		return runner.exec();
 	});
@@ -324,6 +327,14 @@ async function run() {
 				COLCON_DEFAULTS_FILE: colconDefaultsFile,
 			};
 		}
+
+		// Make sure to delete root .colcon directory if it exists
+		// This is because, for some reason, using Docker, commands might get run as root
+		await execBashCommand(
+			`rm -rf ${path.join(path.sep, "root", ".colcon")} || true`,
+			undefined,
+			{ ...options, silent: true }
+		);
 
 		const curlFlags = curlFlagsArray.join(" ");
 		for (const vcsRepoFileUrl of vcsRepoFileUrlListResolved) {


### PR DESCRIPTION
This removes `colcon-mixin-name` and updates examples & tests to use `colcon-defaults` instead.

I also fixed some issues that I uncovered:

* `asan` mixin doesn't exist; `asan-gcc` does
* when setting `options.env`, you probably want to include `process.env`, otherwise the environment gets reset to nothing + whatever you provide with `options.env`; this was making runs that used `colcon-defaults` with C++ packages fail because cmake couldn't find any compiler
* for Docker jobs, `colcon` uses `/root/` as the home directory for some reason (you can see this when the action runs `colcon mixin update ...`), which isn't the same home directory that we use when deleting the `.colcon/` directory to clean up between jobs

Signed-off-by: Christophe Bedard <bedard.christophe@gmail.com>