### PR TITLE
Add test with repos file containing a private repo

### DIFF
--- a/.github/workflows/repo_file_for_test_private_repo.repos
+++ b/.github/workflows/repo_file_for_test_private_repo.repos
@@ -1,0 +1,5 @@
+repositories:
+  private-repo-test:
+    type: git
+    url: https://github.com/ros-tooling/private-repo-test.git
+    version: master

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -135,7 +135,7 @@ jobs:
       - uses: ./
         with:
           import-token: ${{ secrets.GITHUB_TOKEN }}
-          package-name: my_package
+          package-name: simple_package
           target-ros2-distro: foxy
           vcs-repo-file-url: "${{ github.workspace }}/.github/workflows/repo_file_for_test_private_repo.repos"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -127,6 +127,8 @@ jobs:
     name: "Test with private repos"
     runs-on: ubuntu-20.04
     needs: pre_condition
+    # We don't have access to the secret token for the test repo on a fork
+    if: ${{ !github.event.repository.fork && !github.event.pull_request.head.repo.fork }}
     steps:
       - uses: actions/checkout@v2
       - uses: ros-tooling/setup-ros@0.1.2
@@ -134,7 +136,7 @@ jobs:
           required-ros-distributions: foxy
       - uses: ./
         with:
-          import-token: ${{ secrets.GITHUB_TOKEN }}
+          import-token: ${{ secrets.TOKEN_PRIVATE_REPO_TEST }}
           package-name: simple_package
           target-ros2-distro: foxy
           vcs-repo-file-url: "${{ github.workspace }}/.github/workflows/repo_file_for_test_private_repo.repos"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -123,6 +123,22 @@ jobs:
           target-ros2-distro: foxy
           vcs-repo-file-url: "${{ github.workspace }}/.github/workflows/repo_file_for_test_cpp_with_dependency.repos"
 
+  test_private_repo:
+    name: "Test with private repos"
+    runs-on: ubuntu-20.04
+    needs: pre_condition
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ros-tooling/setup-ros@0.1.2
+        with:
+          required-ros-distributions: foxy
+      - uses: ./
+        with:
+          import-token: ${{ secrets.GITHUB_TOKEN }}
+          package-name: my_package
+          target-ros2-distro: foxy
+          vcs-repo-file-url: "${{ github.workspace }}/.github/workflows/repo_file_for_test_private_repo.repos"
+
   test_ros2_docker:
     name: "ROS 2 Docker"
     runs-on: ubuntu-latest

--- a/dist/index.js
+++ b/dist/index.js
@@ -11079,19 +11079,24 @@ function run() {
             yield io.rmRF(rosWorkspaceDir);
             // Checkout ROS 2 from source and install ROS 2 system dependencies
             yield io.mkdirP(rosWorkspaceDir + "/src");
-            if (importToken !== "") {
-                const config = `
-[url "https://${importToken}@github.com"]
-	insteadOf = https://github.com
-[url "http://${importToken}@github.com"]
-	insteadOf = http://github.com`;
-                fs_1.default.appendFileSync(path.join(os.homedir(), ".gitconfig"), config);
-            }
             const options = {
                 cwd: rosWorkspaceDir,
             };
             if (colconDefaultsFile !== "") {
                 options.env = Object.assign(Object.assign({}, process.env), { COLCON_DEFAULTS_FILE: colconDefaultsFile });
+            }
+            if (importToken !== "") {
+                // Unset all local extraheader config entries possibly set by actions/checkout,
+                // because local settings take precedence and the default token used by
+                // actions/checkout might not have the right permissions for any/all repos
+                yield execBashCommand(`/usr/bin/git config --local --unset-all http.https://github.com/.extraheader || true`, undefined, options);
+                yield execBashCommand(String.raw `/usr/bin/git submodule foreach --recursive git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader'` +
+                    ` && git config --local --unset-all 'http.https://github.com/.extraheader' || true`, undefined, options);
+                // Use a global insteadof entry because local configs aren't observed by git clone
+                yield execBashCommand(`/usr/bin/git config --global url.https://${importToken}@github.com.insteadof 'https://github.com'`, undefined, options);
+                if (core.isDebug()) {
+                    yield execBashCommand(`/usr/bin/git config --list --show-origin || true`, undefined, options);
+                }
             }
             // Make sure to delete root .colcon directory if it exists
             // This is because, for some reason, using Docker, commands might get run as root
@@ -11230,7 +11235,10 @@ done`;
                 `--coverage-report-args -m`,
             ].join(" ");
             yield execBashCommand(colconCoveragepyResultCmd, colconCommandPrefix, options);
-            core.setOutput("ros-workspace-directory-name", rosWorkspaceName);
+            if (importToken !== "") {
+                // Unset config so that it doesn't leak to other actions
+                yield execBashCommand(`/usr/bin/git config --global --unset-all url.https://${importToken}@github.com.insteadof`, undefined, options);
+            }
         }
         catch (error) {
             core.setFailed(error.message);


### PR DESCRIPTION
Closes #270

This adds a test that uses `import-token` along with a repos file with a private repo.

Signed-off-by: Christophe Bedard <bedard.christophe@gmail.com>