### PR TITLE
Lower scheduled jobs frequency

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,8 +6,8 @@ on:
       - master
       - "releases/*"
   schedule:
-    # Run the CI automatically every hour to look for flakyness.
-    - cron: "0 * * * *"
+    # Run the CI automatically twice per day to look for flakyness.
+    - cron: "0 */12 * * *"
 
 defaults:
   run:


### PR DESCRIPTION
Tests take sometimes more than an hour to complete, so hourly scheduled jobs gets backed up. This gets even worse when dependabot opens a bunch of PRs every day.

This has led to PR tests being queued for 10h+.

I am proposing to reduce the frequency to twice per day, but anything less frequent than hourly (every 2-4h) would help.