### PR TITLE
Filter out empty elements for package names array

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -11019,6 +11019,7 @@ function run() {
             const packageNames = core
                 .getInput("package-name", { required: true })
                 .split(RegExp("\\s"))
+                .filter((pkgName) => pkgName.length > 0)
                 .join(" ");
             const rosWorkspaceName = "ros_ws";
             core.setOutput("ros-workspace-directory-name", rosWorkspaceName);

--- a/src/action-ros-ci.ts
+++ b/src/action-ros-ci.ts
@@ -221,6 +221,7 @@ async function run() {
 		const packageNames = core
 			.getInput("package-name", { required: true })
 			.split(RegExp("\\s"))
+			.filter((pkgName) => pkgName.length > 0)
 			.join(" ");
 		const rosWorkspaceName = "ros_ws";
 		core.setOutput("ros-workspace-directory-name", rosWorkspaceName);


### PR DESCRIPTION
This is a minor fix that filters out empty elements when extracting an array of package names.

Before:

```yaml
  # ...
  with:
    package-name: ament_copyright
  # ...
```

It includes a space at the end:

```
Invoking: bash -c 'colcon build --event-handlers console_cohesion+ --packages-up-to ament_copyright   --symlink-install'
# ...
Invoking: bash -c 'colcon test --event-handlers console_cohesion+ --return-code-on-test-failure --packages-select ament_copyright '
```

Example:

```ts
let packageNames = `
package_a
package_b
`;
console.log(packageNames.split(RegExp("\\s")));
console.log(packageNames.split(RegExp("\\s")).join(" "));
console.log(packageNames.split(RegExp("\\s")).filter((v) => v.length > 0));
console.log(packageNames.split(RegExp("\\s")).filter((v) => v.length > 0).join(" "));
```

```
["", "package_a", "package_b", ""] 
" package_a package_b " 
["package_a", "package_b"] 
"package_a package_b" 
```

Signed-off-by: Christophe Bedard <bedard.christophe@gmail.com>