### PR TITLE
Always update apt before installing rosdeps

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -11151,6 +11151,10 @@ done`;
             yield execBashCommand("vcs import --force --recursive src/ < package.repo", undefined, options);
             // Print HEAD commits of all repos
             yield execBashCommand("vcs log -l1 src/", undefined, options);
+            if (isLinux) {
+                // Always update APT before installing packages on Ubuntu
+                yield execBashCommand("sudo apt-get update");
+            }
             yield installRosdeps(packageNames, rosWorkspaceDir, targetRos1Distro, targetRos2Distro);
             if (colconDefaults.includes(`"mixin"`) && colconMixinRepo !== "") {
                 yield execBashCommand(`colcon mixin add default '${colconMixinRepo}'`, undefined, options);

--- a/src/action-ros-ci.ts
+++ b/src/action-ros-ci.ts
@@ -408,6 +408,10 @@ done`;
 		// Print HEAD commits of all repos
 		await execBashCommand("vcs log -l1 src/", undefined, options);
 
+		if (isLinux) {
+			// Always update APT before installing packages on Ubuntu
+			await execBashCommand("sudo apt-get update");
+		}
 		await installRosdeps(
 			packageNames,
 			rosWorkspaceDir,


### PR DESCRIPTION
When running on `setup-ros-docker` images, there is no guarantee that `apt-get update` was run any time recently. When `setup-ros-docker` workflows were disabled for a little while (due to repository inactivity), this got so out of date that every user started failing because of out-of-date APT endpoints. We should have an expectation that the same code version should continue building on the same image, even if new images are not being created. This diff ensures that will be true.