### PR TITLE
Add galactic to valid distros list to support binary installs

### DIFF
--- a/__tests__/ros-ci.test.ts
+++ b/__tests__/ros-ci.test.ts
@@ -32,12 +32,23 @@ describe("execBashCommand test suite", () => {
 describe("validate distribution test", () => {
 	it("validates that the ros distribution validator acts correctly", async () => {
 		expect(actionRosCi.validateDistros("kinetic", "")).toBe(true);
-		expect(actionRosCi.validateDistros("melodic", "dashing")).toBe(true);
+		expect(actionRosCi.validateDistros("lunar", "")).toBe(true);
+		expect(actionRosCi.validateDistros("melodic", "")).toBe(true);
+		expect(actionRosCi.validateDistros("noetic", "")).toBe(true);
+		expect(actionRosCi.validateDistros("", "dashing")).toBe(true);
 		expect(actionRosCi.validateDistros("", "eloquent")).toBe(true);
+		expect(actionRosCi.validateDistros("", "foxy")).toBe(true);
+		expect(actionRosCi.validateDistros("", "galactic")).toBe(true);
+		expect(actionRosCi.validateDistros("", "rolling")).toBe(true);
+
+		expect(actionRosCi.validateDistros("noetic", "rolling")).toBe(true);
+		expect(actionRosCi.validateDistros("melodic", "dashing")).toBe(true);
+
 		expect(actionRosCi.validateDistros("", "")).toBe(false);
 		expect(actionRosCi.validateDistros("groovy", "")).toBe(false);
 		expect(actionRosCi.validateDistros("", "bouncy")).toBe(false);
 		expect(actionRosCi.validateDistros("apples", "bananas")).toBe(false);
+		expect(actionRosCi.validateDistros("apples", "rolling")).toBe(false);
 	});
 });
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -10869,7 +10869,13 @@ const curlFlagsArray = [
     "--location",
 ];
 const validROS1Distros = ["kinetic", "lunar", "melodic", "noetic"];
-const validROS2Distros = ["dashing", "eloquent", "foxy", "rolling"];
+const validROS2Distros = [
+    "dashing",
+    "eloquent",
+    "foxy",
+    "galactic",
+    "rolling",
+];
 const targetROS1DistroInput = "target-ros1-distro";
 const targetROS2DistroInput = "target-ros2-distro";
 const isLinux = process.platform == "linux";

--- a/src/action-ros-ci.ts
+++ b/src/action-ros-ci.ts
@@ -41,7 +41,13 @@ const curlFlagsArray = [
 ];
 
 const validROS1Distros: string[] = ["kinetic", "lunar", "melodic", "noetic"];
-const validROS2Distros: string[] = ["dashing", "eloquent", "foxy", "rolling"];
+const validROS2Distros: string[] = [
+	"dashing",
+	"eloquent",
+	"foxy",
+	"galactic",
+	"rolling",
+];
 const targetROS1DistroInput: string = "target-ros1-distro";
 const targetROS2DistroInput: string = "target-ros2-distro";
 const isLinux: boolean = process.platform == "linux";


### PR DESCRIPTION
Part of https://github.com/ros-tooling/action-ros-ci/issues/640

This allows users to use `target-ros2-distro: galactic` (to use a Galactic binary installation). Note that users must currently use the testing repository to get Galactic binaries. See https://github.com/ros-tooling/setup-ros/pull/387

Users can still build Galactic from source until then.

Signed-off-by: Christophe Bedard <bedard.christophe@gmail.com>