### PR TITLE
Make dependabot run weekly instead of daily

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,12 +3,12 @@ updates:
   - package-ecosystem: npm
     directory: "/"
     schedule:
-      interval: daily
+      interval: weekly
       time: "16:00"
     open-pull-requests-limit: 10
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
-      interval: daily
+      interval: weekly
       time: "16:00"
     open-pull-requests-limit: 10


### PR DESCRIPTION
It runs daily and basically kills the CI queue. For example, I've been trying to get #642 merged, but by the time CI has run, the branch is out of date, so I have to merge `master` into it, and then it goes to the end of the CI queue again. Rinse and repeat! :laughing:

We recommend pointing to a release instead of `master`, so there isn't much benefit to it running daily.

Signed-off-by: Christophe Bedard <bedard.christophe@gmail.com>