### PR TITLE
Run dependabot daily, but limit open PRs to reduce notification noise

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,12 +3,12 @@ updates:
   - package-ecosystem: npm
     directory: "/"
     schedule:
-      interval: weekly
+      interval: daily
       time: "16:00"
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
-      interval: weekly
+      interval: daily
       time: "16:00"
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 1


### PR DESCRIPTION
setup-ros has been a lot less annoying, with this setup. applying here as well to reduce the noise in my notification feed