### PR TITLE
Remove cURL in favor of using vcstool's ability to import URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@ This action builds and tests a [ROS](http://wiki.ros.org/) or [ROS 2](https://do
 This action requires the following ROS development tools to be installed (and initialized if applicable) on the CI worker instance:
 
 ```
-curl
 colcon-common-extensions
 colcon-lcov-result  # Optional
 colcon-coveragepy-result

--- a/dist/index.js
+++ b/dist/index.js
@@ -7,14 +7,27 @@ module.exports =
 
 "use strict";
 
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    Object.defineProperty(o, k2, { enumerable: true, get: function() { return m[k]; } });
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
 var __importStar = (this && this.__importStar) || function (mod) {
     if (mod && mod.__esModule) return mod;
     var result = {};
-    if (mod != null) for (var k in mod) if (Object.hasOwnProperty.call(mod, k)) result[k] = mod[k];
-    result["default"] = mod;
+    if (mod != null) for (var k in mod) if (k !== "default" && Object.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    __setModuleDefault(result, mod);
     return result;
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.issue = exports.issueCommand = void 0;
 const os = __importStar(__nccwpck_require__(2087));
 const utils_1 = __nccwpck_require__(5278);
 /**
@@ -93,6 +106,25 @@ function escapeProperty(s) {
 
 "use strict";
 
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    Object.defineProperty(o, k2, { enumerable: true, get: function() { return m[k]; } });
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (k !== "default" && Object.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    __setModuleDefault(result, mod);
+    return result;
+};
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -102,14 +134,8 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
         step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
 };
-var __importStar = (this && this.__importStar) || function (mod) {
-    if (mod && mod.__esModule) return mod;
-    var result = {};
-    if (mod != null) for (var k in mod) if (Object.hasOwnProperty.call(mod, k)) result[k] = mod[k];
-    result["default"] = mod;
-    return result;
-};
 Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.getState = exports.saveState = exports.group = exports.endGroup = exports.startGroup = exports.info = exports.warning = exports.error = exports.debug = exports.isDebug = exports.setFailed = exports.setCommandEcho = exports.setOutput = exports.getBooleanInput = exports.getMultilineInput = exports.getInput = exports.addPath = exports.setSecret = exports.exportVariable = exports.ExitCode = void 0;
 const command_1 = __nccwpck_require__(7351);
 const file_command_1 = __nccwpck_require__(717);
 const utils_1 = __nccwpck_require__(5278);
@@ -176,7 +202,9 @@ function addPath(inputPath) {
 }
 exports.addPath = addPath;
 /**
- * Gets the value of an input.  The value is also trimmed.
+ * Gets the value of an input.
+ * Unless trimWhitespace is set to false in InputOptions, the value is also trimmed.
+ * Returns an empty string if the value is not defined.
  *
  * @param     name     name of the input to get
  * @param     options  optional. See InputOptions.
@@ -187,9 +215,49 @@ function getInput(name, options) {
     if (options && options.required && !val) {
         throw new Error(`Input required and not supplied: ${name}`);
     }
+    if (options && options.trimWhitespace === false) {
+        return val;
+    }
     return val.trim();
 }
 exports.getInput = getInput;
+/**
+ * Gets the values of an multiline input.  Each value is also trimmed.
+ *
+ * @param     name     name of the input to get
+ * @param     options  optional. See InputOptions.
+ * @returns   string[]
+ *
+ */
+function getMultilineInput(name, options) {
+    const inputs = getInput(name, options)
+        .split('\n')
+        .filter(x => x !== '');
+    return inputs;
+}
+exports.getMultilineInput = getMultilineInput;
+/**
+ * Gets the input value of the boolean type in the YAML 1.2 "core schema" specification.
+ * Support boolean input list: `true | True | TRUE | false | False | FALSE` .
+ * The return value is also in boolean type.
+ * ref: https://yaml.org/spec/1.2/spec.html#id2804923
+ *
+ * @param     name     name of the input to get
+ * @param     options  optional. See InputOptions.
+ * @returns   boolean
+ */
+function getBooleanInput(name, options) {
+    const trueValue = ['true', 'True', 'TRUE'];
+    const falseValue = ['false', 'False', 'FALSE'];
+    const val = getInput(name, options);
+    if (trueValue.includes(val))
+        return true;
+    if (falseValue.includes(val))
+        return false;
+    throw new TypeError(`Input does not meet YAML 1.2 "Core Schema" specification: ${name}\n` +
+        `Support boolean input list: \`true | True | TRUE | false | False | FALSE\``);
+}
+exports.getBooleanInput = getBooleanInput;
 /**
  * Sets the value of an output.
  *
@@ -340,14 +408,27 @@ exports.getState = getState;
 "use strict";
 
 // For internal use, subject to change.
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    Object.defineProperty(o, k2, { enumerable: true, get: function() { return m[k]; } });
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
 var __importStar = (this && this.__importStar) || function (mod) {
     if (mod && mod.__esModule) return mod;
     var result = {};
-    if (mod != null) for (var k in mod) if (Object.hasOwnProperty.call(mod, k)) result[k] = mod[k];
-    result["default"] = mod;
+    if (mod != null) for (var k in mod) if (k !== "default" && Object.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    __setModuleDefault(result, mod);
     return result;
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.issueCommand = void 0;
 // We use any as a valid input type
 /* eslint-disable @typescript-eslint/no-explicit-any */
 const fs = __importStar(__nccwpck_require__(5747));
@@ -378,6 +459,7 @@ exports.issueCommand = issueCommand;
 // We use any as a valid input type
 /* eslint-disable @typescript-eslint/no-explicit-any */
 Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.toCommandValue = void 0;
 /**
  * Sanitizes an input into a string so it can be passed into issueCommand safely
  * @param input input to sanitize into a string
@@ -1833,11 +1915,18 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
         step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
 };
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (Object.hasOwnProperty.call(mod, k)) result[k] = mod[k];
+    result["default"] = mod;
+    return result;
+};
 var _a;
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 const assert_1 = __nccwpck_require__(2357);
-const fs = __nccwpck_require__(5747);
-const path = __nccwpck_require__(5622);
+const fs = __importStar(__nccwpck_require__(5747));
+const path = __importStar(__nccwpck_require__(5622));
 _a = fs.promises, exports.chmod = _a.chmod, exports.copyFile = _a.copyFile, exports.lstat = _a.lstat, exports.mkdir = _a.mkdir, exports.readdir = _a.readdir, exports.readlink = _a.readlink, exports.rename = _a.rename, exports.rmdir = _a.rmdir, exports.stat = _a.stat, exports.symlink = _a.symlink, exports.unlink = _a.unlink;
 exports.IS_WINDOWS = process.platform === 'win32';
 function exists(fsPath) {
@@ -2035,11 +2124,18 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
         step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
 };
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (Object.hasOwnProperty.call(mod, k)) result[k] = mod[k];
+    result["default"] = mod;
+    return result;
+};
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-const childProcess = __nccwpck_require__(3129);
-const path = __nccwpck_require__(5622);
+const childProcess = __importStar(__nccwpck_require__(3129));
+const path = __importStar(__nccwpck_require__(5622));
 const util_1 = __nccwpck_require__(1669);
-const ioUtil = __nccwpck_require__(1962);
+const ioUtil = __importStar(__nccwpck_require__(1962));
 const exec = util_1.promisify(childProcess.exec);
 /**
  * Copies a file or folder.
@@ -2207,58 +2303,73 @@ function which(tool, check) {
                     throw new Error(`Unable to locate executable file: ${tool}. Please verify either the file path exists or the file can be found within a directory specified by the PATH environment variable. Also check the file mode to verify the file is executable.`);
                 }
             }
+            return result;
         }
-        try {
-            // build the list of extensions to try
-            const extensions = [];
-            if (ioUtil.IS_WINDOWS && process.env.PATHEXT) {
-                for (const extension of process.env.PATHEXT.split(path.delimiter)) {
-                    if (extension) {
-                        extensions.push(extension);
-                    }
-                }
-            }
-            // if it's rooted, return it if exists. otherwise return empty.
-            if (ioUtil.isRooted(tool)) {
-                const filePath = yield ioUtil.tryGetExecutablePath(tool, extensions);
-                if (filePath) {
-                    return filePath;
-                }
-                return '';
-            }
-            // if any path separators, return empty
-            if (tool.includes('/') || (ioUtil.IS_WINDOWS && tool.includes('\\'))) {
-                return '';
-            }
-            // build the list of directories
-            //
-            // Note, technically "where" checks the current directory on Windows. From a toolkit perspective,
-            // it feels like we should not do this. Checking the current directory seems like more of a use
-            // case of a shell, and the which() function exposed by the toolkit should strive for consistency
-            // across platforms.
-            const directories = [];
-            if (process.env.PATH) {
-                for (const p of process.env.PATH.split(path.delimiter)) {
-                    if (p) {
-                        directories.push(p);
-                    }
-                }
-            }
-            // return the first match
-            for (const directory of directories) {
-                const filePath = yield ioUtil.tryGetExecutablePath(directory + path.sep + tool, extensions);
-                if (filePath) {
-                    return filePath;
-                }
-            }
-            return '';
+        const matches = yield findInPath(tool);
+        if (matches && matches.length > 0) {
+            return matches[0];
         }
-        catch (err) {
-            throw new Error(`which failed with message ${err.message}`);
-        }
+        return '';
     });
 }
 exports.which = which;
+/**
+ * Returns a list of all occurrences of the given tool on the system path.
+ *
+ * @returns   Promise<string[]>  the paths of the tool
+ */
+function findInPath(tool) {
+    return __awaiter(this, void 0, void 0, function* () {
+        if (!tool) {
+            throw new Error("parameter 'tool' is required");
+        }
+        // build the list of extensions to try
+        const extensions = [];
+        if (ioUtil.IS_WINDOWS && process.env['PATHEXT']) {
+            for (const extension of process.env['PATHEXT'].split(path.delimiter)) {
+                if (extension) {
+                    extensions.push(extension);
+                }
+            }
+        }
+        // if it's rooted, return it if exists. otherwise return empty.
+        if (ioUtil.isRooted(tool)) {
+            const filePath = yield ioUtil.tryGetExecutablePath(tool, extensions);
+            if (filePath) {
+                return [filePath];
+            }
+            return [];
+        }
+        // if any path separators, return empty
+        if (tool.includes(path.sep)) {
+            return [];
+        }
+        // build the list of directories
+        //
+        // Note, technically "where" checks the current directory on Windows. From a toolkit perspective,
+        // it feels like we should not do this. Checking the current directory seems like more of a use
+        // case of a shell, and the which() function exposed by the toolkit should strive for consistency
+        // across platforms.
+        const directories = [];
+        if (process.env.PATH) {
+            for (const p of process.env.PATH.split(path.delimiter)) {
+                if (p) {
+                    directories.push(p);
+                }
+            }
+        }
+        // find all matches
+        const matches = [];
+        for (const directory of directories) {
+            const filePath = yield ioUtil.tryGetExecutablePath(path.join(directory, tool), extensions);
+            if (filePath) {
+                matches.push(filePath);
+            }
+        }
+        return matches;
+    });
+}
+exports.findInPath = findInPath;
 function readCopyOptions(options) {
     const force = options.force == null ? true : options.force;
     const recursive = Boolean(options.recursive);
@@ -10839,6 +10950,7 @@ const tr = __importStar(__nccwpck_require__(8159));
 const io = __importStar(__nccwpck_require__(7436));
 const os = __importStar(__nccwpck_require__(2087));
 const path = __importStar(__nccwpck_require__(5622));
+const url = __importStar(__nccwpck_require__(8835));
 const fs_1 = __importDefault(__nccwpck_require__(5747));
 const async_retry_1 = __importDefault(__nccwpck_require__(3415));
 const dep = __importStar(__nccwpck_require__(7760));
@@ -10891,7 +11003,7 @@ function isValidJson(str) {
  */
 function resolveVcsRepoFileUrl(vcsRepoFileUrl) {
     if (fs_1.default.existsSync(vcsRepoFileUrl)) {
-        return "file://" + path.resolve(vcsRepoFileUrl);
+        return url.pathToFileURL(path.resolve(vcsRepoFileUrl)).href;
     }
     else {
         return vcsRepoFileUrl;

--- a/src/action-ros-ci.ts
+++ b/src/action-ros-ci.ts
@@ -5,6 +5,7 @@ import * as tr from "@actions/exec/lib/toolrunner";
 import * as io from "@actions/io";
 import * as os from "os";
 import * as path from "path";
+import * as url from "url";
 import fs from "fs";
 import retry from "async-retry";
 import * as dep from "./dependencies";
@@ -59,7 +60,7 @@ function isValidJson(str: string): boolean {
  */
 function resolveVcsRepoFileUrl(vcsRepoFileUrl: string): string {
 	if (fs.existsSync(vcsRepoFileUrl)) {
-		return "file://" + path.resolve(vcsRepoFileUrl);
+		return url.pathToFileURL(path.resolve(vcsRepoFileUrl)).href;
 	} else {
 		return vcsRepoFileUrl;
 	}

--- a/src/action-ros-ci.ts
+++ b/src/action-ros-ci.ts
@@ -48,6 +48,24 @@ function isValidJson(str: string): boolean {
 }
 
 /**
+ * Convert local paths to URLs.
+ *
+ * The user can pass the VCS repo file either as a URL or a path.
+ * If it is a path, this function will convert it into a URL (file://...).
+ * If the file is already passed as an URL, this function does nothing.
+ *
+ * @param   vcsRepoFileUrl     path or URL to the repo file
+ * @returns                    URL to the repo file
+ */
+function resolveVcsRepoFileUrl(vcsRepoFileUrl: string): string {
+	if (fs.existsSync(vcsRepoFileUrl)) {
+		return "file://" + path.resolve(vcsRepoFileUrl);
+	} else {
+		return vcsRepoFileUrl;
+	}
+}
+
+/**
  * Execute a command in bash and wrap the output in a log group.
  *
  * @param   commandLine     command to execute (can include additional args). Must be correctly escaped.
@@ -326,8 +344,9 @@ async function run_throw(): Promise<void> {
 	);
 
 	for (const vcsRepoFileUrl of vcsRepoFileUrlListNonEmpty) {
+		const resolvedUrl = resolveVcsRepoFileUrl(vcsRepoFileUrl);
 		await execBashCommand(
-			`vcs import --force --recursive src/ --input ${vcsRepoFileUrl}`,
+			`vcs import --force --recursive src/ --input ${resolvedUrl}`,
 			undefined,
 			options
 		);
@@ -378,7 +397,7 @@ done`;
     version: '${commitRef}'`;
 	fs.writeFileSync(repoFilePath, repoFileContent);
 	await execBashCommand(
-		"vcs import --force --recursive src/ --input package.repo",
+		"vcs import --force --recursive src/ < package.repo",
 		undefined,
 		options
 	);

--- a/src/action-ros-ci.ts
+++ b/src/action-ros-ci.ts
@@ -9,37 +9,6 @@ import fs from "fs";
 import retry from "async-retry";
 import * as dep from "./dependencies";
 
-// All command line flags passed to curl when invoked as a command.
-const curlFlagsArray = [
-	// (HTTP)  Fail  silently  (no  output at all) on server errors. This is mostly done to better enable
-	// scripts etc to better deal with failed attempts. In normal cases  when  a  HTTP  server  fails  to
-	// deliver  a  document,  it  returns an HTML document stating so (which often also describes why and
-	// more). This flag will prevent curl from outputting that and return error 22.
-	// This method is not fail-safe and there are occasions where non-successful response codes will slip
-	// through, especially when authentication is involved (response codes 401 and 407).
-	"--fail",
-
-	// Silent or quiet mode. Don't show progress meter or error messages.  Makes Curl mute.
-	"--silent",
-
-	// When used with -s it makes curl show an error message if it fails.
-	"--show-error",
-
-	// (HTTP/HTTPS) If the server reports that the requested page  has  moved  to  a  different  location
-	// (indicated  with  a Location: header and a 3XX response code), this option will make curl redo the
-	// request on the new place. If used together with -i, --include or  -I,  --head,  headers  from  all
-	// requested pages will be shown. When authentication is used, curl only sends its credentials to the
-	// initial host. If a redirect takes curl to a different host, it won't  be  able  to  intercept  the
-	// user+password.  See  also  --location-trusted  on  how to change this. You can limit the amount of
-	// redirects to follow by using the --max-redirs option.
-	//
-	// When curl follows a redirect and the request is not a plain GET (for example POST or PUT), it will
-	// do  the  following  request  with a GET if the HTTP response was 301, 302, or 303. If the response
-	// code was any other 3xx code, curl will re-send the following request  using  the  same  unmodified
-	// method.
-	"--location",
-];
-
 const validROS1Distros: string[] = ["kinetic", "lunar", "melodic", "noetic"];
 const validROS2Distros: string[] = [
 	"dashing",
@@ -76,24 +45,6 @@ function isValidJson(str: string): boolean {
 		return false;
 	}
 	return true;
-}
-
-/**
- * Convert local paths to URLs.
- *
- * The user can pass the VCS repo file either as a URL or a path.
- * If it is a path, this function will convert it into a URL (file://...).
- * If the file is already passed as an URL, this function does nothing.
- *
- * @param   vcsRepoFileUrl     path or URL to the repo file
- * @returns                    URL to the repo file
- */
-function resolveVcsRepoFileUrl(vcsRepoFileUrl: string): string {
-	if (fs.existsSync(vcsRepoFileUrl)) {
-		return "file://" + path.resolve(vcsRepoFileUrl);
-	} else {
-		return vcsRepoFileUrl;
-	}
 }
 
 /**
@@ -282,9 +233,6 @@ async function run_throw(): Promise<void> {
 	vcsRepoFileUrlList = vcsRepoFileUrlList.concat(vcsReposSupplemental);
 
 	const vcsRepoFileUrlListNonEmpty = vcsRepoFileUrlList.filter((x) => x != "");
-	const vcsRepoFileUrlListResolved = vcsRepoFileUrlListNonEmpty.map((x) =>
-		resolveVcsRepoFileUrl(x)
-	);
 
 	const coverageIgnorePattern = core.getInput("coverage-ignore-pattern");
 
@@ -377,10 +325,9 @@ async function run_throw(): Promise<void> {
 		{ ...options, silent: true }
 	);
 
-	const curlFlags = curlFlagsArray.join(" ");
-	for (const vcsRepoFileUrl of vcsRepoFileUrlListResolved) {
+	for (const vcsRepoFileUrl of vcsRepoFileUrlListNonEmpty) {
 		await execBashCommand(
-			`curl ${curlFlags} '${vcsRepoFileUrl}' | vcs import --force --recursive src/`,
+			`vcs import --force --recursive src/ --input ${vcsRepoFileUrl}`,
 			undefined,
 			options
 		);
@@ -431,7 +378,7 @@ done`;
     version: '${commitRef}'`;
 	fs.writeFileSync(repoFilePath, repoFileContent);
 	await execBashCommand(
-		"vcs import --force --recursive src/ < package.repo",
+		"vcs import --force --recursive src/ --input package.repo",
 		undefined,
 		options
 	);


### PR DESCRIPTION
Replaces #328 (thanks @rotu for starting it)

`vcstool` can take URLs, we can simplify logic by using this instead of expecting curl installed, or configuring it with advanced options