### PR TITLE
Add 'skip-tests' option

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -341,6 +341,19 @@ jobs:
       - run: grep -q 9ae391a63628efe6d72ba34a1a1d9dc9 ./${{ steps.test_extra_cmake.outputs.ros-workspace-directory-name }}/build/ament_cmake_core/CMakeCache.txt
         name: "Check that the additional extra flags has been correctly passed"
 
+      - uses: ./
+        id: test_skip_tests
+        name: "Test single package, skip tests"
+        with:
+          package-name: ament_copyright
+          target-ros2-distro: ${{ matrix.ros_distribution }}
+          vcs-repo-file-url: ${{ env.DISTRO_REPOS_URL }}
+          skip-tests: true
+      - run: test -d "${{ steps.test_skip_tests.outputs.ros-workspace-directory-name }}/build/ament_copyright"
+        name: "Check that a build directory exists for ament_copyright"
+      - run: test ! -f "${{ steps.test_skip_tests.outputs.ros-workspace-directory-name }}/build/ament_copyright/colcon_test.rc"
+        name: "Check that 'colcon test' wasn't run on ament_copyright"
+
   test_ros2_from_source_docker:
     name: "Test ROS 2 from source Docker"
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ This action builds and tests a [ROS](http://wiki.ros.org/) or [ROS 2](https://do
    1. [Build and run tests for your ROS 2 package](#Build-and-run-tests-for-your-ROS-2-package)
    1. [Build with a custom `repos` or `rosinstall` file](#Build-with-a-custom-repos-or-rosinstall-file)
    1. [Build a ROS 1 workspace](#Build-a-ROS-1-workspace)
+   1. [Skip tests](#Skip-tests)
    1. [Use a `colcon` `defaults.yaml` file](#Use-a-colcon-defaultsyaml-file)
    1. [Enable Address Sanitizer to automatically report memory issues](#Enable-Address-Sanitizer-to-automatically-report-memory-issues)
    1. [Generate and process code coverage data](#Generate-and-process-code-coverage-data)
@@ -47,7 +48,7 @@ The workspace is built by running:
 - checkout the code under test in the workspace using `vcs`
 - `rosdep install` for the workspace, to get its dependencies
 - run `colcon build` (optionally limited to packages specified in `package-name`)
-- run `colcon test` (optionally limited to packages specified in `package-name`)
+- run `colcon test` (optionally limited to packages specified in `package-name`; optionally [skipped](#Skip-tests))
 
 This action requires targeting a ROS or ROS 2 distribution explicitly.
 This is provided via the `target-ros1-distro` or `target-ros2-distro` inputs, respectively.
@@ -137,6 +138,22 @@ steps:
     with:
       package-name: my_package
       target-ros1-distro: melodic
+```
+
+### Skip tests
+
+To skip tests and code coverage data processing, set the `skip-tests` option to `true`.
+
+```yaml
+steps:
+  - uses: ros-tooling/setup-ros@v0.2
+    with:
+      required-ros-distributions: galactic
+  - uses: ros-tooling/action-ros-ci@v0.2
+    with:
+      package-name: my_package
+      target-ros2-distro: galactic
+      skip-tests: true
 ```
 
 ### Use a `colcon` `defaults.yaml` file

--- a/action.yml
+++ b/action.yml
@@ -71,6 +71,12 @@ inputs:
       For example, for ROS 2 Rolling source repositories, use:
       https://raw.githubusercontent.com/ros2/ros2/master/ros2.repos
     default: ""
+  skip-tests:
+    default: ""
+    description: |
+      Skip tests and code coverage data processing.
+      Set to 'true'.
+    required: false
 outputs:
   ros-workspace-directory-name:
     description: |


### PR DESCRIPTION
Closes #684

This adds a `skip-tests` option. When set to `true`, it skips tests and coverage data processing.

When the option is enabled, the action prints "Skipping tests" right after `colcon build`.

Signed-off-by: Christophe Bedard <bedard.christophe@gmail.com>