### PR TITLE
Add sourceCommandPrefix in installRosdeps to handle dependencies with conditions

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -1906,6 +1906,25 @@ exports.checkBypass = checkBypass;
 
 "use strict";
 
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    Object.defineProperty(o, k2, { enumerable: true, get: function() { return m[k]; } });
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (k !== "default" && Object.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    __setModuleDefault(result, mod);
+    return result;
+};
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -1915,16 +1934,9 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
         step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
 };
-var __importStar = (this && this.__importStar) || function (mod) {
-    if (mod && mod.__esModule) return mod;
-    var result = {};
-    if (mod != null) for (var k in mod) if (Object.hasOwnProperty.call(mod, k)) result[k] = mod[k];
-    result["default"] = mod;
-    return result;
-};
 var _a;
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-const assert_1 = __nccwpck_require__(2357);
+exports.getCmdPath = exports.tryGetExecutablePath = exports.isRooted = exports.isDirectory = exports.exists = exports.IS_WINDOWS = exports.unlink = exports.symlink = exports.stat = exports.rmdir = exports.rename = exports.readlink = exports.readdir = exports.mkdir = exports.lstat = exports.copyFile = exports.chmod = void 0;
 const fs = __importStar(__nccwpck_require__(5747));
 const path = __importStar(__nccwpck_require__(5622));
 _a = fs.promises, exports.chmod = _a.chmod, exports.copyFile = _a.copyFile, exports.lstat = _a.lstat, exports.mkdir = _a.mkdir, exports.readdir = _a.readdir, exports.readlink = _a.readlink, exports.rename = _a.rename, exports.rmdir = _a.rmdir, exports.stat = _a.stat, exports.symlink = _a.symlink, exports.unlink = _a.unlink;
@@ -1967,49 +1979,6 @@ function isRooted(p) {
     return p.startsWith('/');
 }
 exports.isRooted = isRooted;
-/**
- * Recursively create a directory at `fsPath`.
- *
- * This implementation is optimistic, meaning it attempts to create the full
- * path first, and backs up the path stack from there.
- *
- * @param fsPath The path to create
- * @param maxDepth The maximum recursion depth
- * @param depth The current recursion depth
- */
-function mkdirP(fsPath, maxDepth = 1000, depth = 1) {
-    return __awaiter(this, void 0, void 0, function* () {
-        assert_1.ok(fsPath, 'a path argument must be provided');
-        fsPath = path.resolve(fsPath);
-        if (depth >= maxDepth)
-            return exports.mkdir(fsPath);
-        try {
-            yield exports.mkdir(fsPath);
-            return;
-        }
-        catch (err) {
-            switch (err.code) {
-                case 'ENOENT': {
-                    yield mkdirP(path.dirname(fsPath), maxDepth, depth + 1);
-                    yield exports.mkdir(fsPath);
-                    return;
-                }
-                default: {
-                    let stats;
-                    try {
-                        stats = yield exports.stat(fsPath);
-                    }
-                    catch (err2) {
-                        throw err;
-                    }
-                    if (!stats.isDirectory())
-                        throw err;
-                }
-            }
-        }
-    });
-}
-exports.mkdirP = mkdirP;
 /**
  * Best effort attempt to determine whether a file exists and is executable.
  * @param filePath    file path to check
@@ -2106,6 +2075,12 @@ function isUnixExecutable(stats) {
         ((stats.mode & 8) > 0 && stats.gid === process.getgid()) ||
         ((stats.mode & 64) > 0 && stats.uid === process.getuid()));
 }
+// Get the path of cmd.exe in windows
+function getCmdPath() {
+    var _a;
+    return (_a = process.env['COMSPEC']) !== null && _a !== void 0 ? _a : `cmd.exe`;
+}
+exports.getCmdPath = getCmdPath;
 //# sourceMappingURL=io-util.js.map
 
 /***/ }),
@@ -2115,6 +2090,25 @@ function isUnixExecutable(stats) {
 
 "use strict";
 
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    Object.defineProperty(o, k2, { enumerable: true, get: function() { return m[k]; } });
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (k !== "default" && Object.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    __setModuleDefault(result, mod);
+    return result;
+};
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -2124,19 +2118,15 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
         step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
 };
-var __importStar = (this && this.__importStar) || function (mod) {
-    if (mod && mod.__esModule) return mod;
-    var result = {};
-    if (mod != null) for (var k in mod) if (Object.hasOwnProperty.call(mod, k)) result[k] = mod[k];
-    result["default"] = mod;
-    return result;
-};
 Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.findInPath = exports.which = exports.mkdirP = exports.rmRF = exports.mv = exports.cp = void 0;
+const assert_1 = __nccwpck_require__(2357);
 const childProcess = __importStar(__nccwpck_require__(3129));
 const path = __importStar(__nccwpck_require__(5622));
 const util_1 = __nccwpck_require__(1669);
 const ioUtil = __importStar(__nccwpck_require__(1962));
 const exec = util_1.promisify(childProcess.exec);
+const execFile = util_1.promisify(childProcess.execFile);
 /**
  * Copies a file or folder.
  * Based off of shelljs - https://github.com/shelljs/shelljs/blob/9237f66c52e5daa40458f94f9565e18e8132f5a6/src/cp.js
@@ -2147,14 +2137,14 @@ const exec = util_1.promisify(childProcess.exec);
  */
 function cp(source, dest, options = {}) {
     return __awaiter(this, void 0, void 0, function* () {
-        const { force, recursive } = readCopyOptions(options);
+        const { force, recursive, copySourceDirectory } = readCopyOptions(options);
         const destStat = (yield ioUtil.exists(dest)) ? yield ioUtil.stat(dest) : null;
         // Dest is an existing file, but not forcing
         if (destStat && destStat.isFile() && !force) {
             return;
         }
         // If dest is an existing directory, should copy inside.
-        const newDest = destStat && destStat.isDirectory()
+        const newDest = destStat && destStat.isDirectory() && copySourceDirectory
             ? path.join(dest, path.basename(source))
             : dest;
         if (!(yield ioUtil.exists(source))) {
@@ -2219,12 +2209,22 @@ function rmRF(inputPath) {
         if (ioUtil.IS_WINDOWS) {
             // Node doesn't provide a delete operation, only an unlink function. This means that if the file is being used by another
             // program (e.g. antivirus), it won't be deleted. To address this, we shell out the work to rd/del.
+            // Check for invalid characters
+            // https://docs.microsoft.com/en-us/windows/win32/fileio/naming-a-file
+            if (/[*"<>|]/.test(inputPath)) {
+                throw new Error('File path must not contain `*`, `"`, `<`, `>` or `|` on Windows');
+            }
             try {
+                const cmdPath = ioUtil.getCmdPath();
                 if (yield ioUtil.isDirectory(inputPath, true)) {
-                    yield exec(`rd /s /q "${inputPath}"`);
+                    yield exec(`${cmdPath} /s /c "rd /s /q "%inputPath%""`, {
+                        env: { inputPath }
+                    });
                 }
                 else {
-                    yield exec(`del /f /a "${inputPath}"`);
+                    yield exec(`${cmdPath} /s /c "del /f /a "%inputPath%""`, {
+                        env: { inputPath }
+                    });
                 }
             }
             catch (err) {
@@ -2257,7 +2257,7 @@ function rmRF(inputPath) {
                 return;
             }
             if (isDir) {
-                yield exec(`rm -rf "${inputPath}"`);
+                yield execFile(`rm`, [`-rf`, `${inputPath}`]);
             }
             else {
                 yield ioUtil.unlink(inputPath);
@@ -2275,7 +2275,8 @@ exports.rmRF = rmRF;
  */
 function mkdirP(fsPath) {
     return __awaiter(this, void 0, void 0, function* () {
-        yield ioUtil.mkdirP(fsPath);
+        assert_1.ok(fsPath, 'a path argument must be provided');
+        yield ioUtil.mkdir(fsPath, { recursive: true });
     });
 }
 exports.mkdirP = mkdirP;
@@ -2373,7 +2374,10 @@ exports.findInPath = findInPath;
 function readCopyOptions(options) {
     const force = options.force == null ? true : options.force;
     const recursive = Boolean(options.recursive);
-    return { force, recursive };
+    const copySourceDirectory = options.copySourceDirectory == null
+        ? true
+        : Boolean(options.copySourceDirectory);
+    return { force, recursive, copySourceDirectory };
 }
 function cpDirRecursive(sourceDir, destDir, currentDepth, force) {
     return __awaiter(this, void 0, void 0, function* () {
@@ -10945,14 +10949,14 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.validateDistros = exports.execBashCommand = exports.filterNonEmptyJoin = void 0;
 const core = __importStar(__nccwpck_require__(2186));
-const github = __importStar(__nccwpck_require__(5438));
 const tr = __importStar(__nccwpck_require__(8159));
+const github = __importStar(__nccwpck_require__(5438));
 const io = __importStar(__nccwpck_require__(7436));
+const async_retry_1 = __importDefault(__nccwpck_require__(3415));
+const fs_1 = __importDefault(__nccwpck_require__(5747));
 const os = __importStar(__nccwpck_require__(2087));
 const path = __importStar(__nccwpck_require__(5622));
 const url = __importStar(__nccwpck_require__(8835));
-const fs_1 = __importDefault(__nccwpck_require__(5747));
-const async_retry_1 = __importDefault(__nccwpck_require__(3415));
 const dep = __importStar(__nccwpck_require__(7760));
 const validROS1Distros = ["kinetic", "lunar", "melodic", "noetic"];
 const validROS2Distros = [
@@ -11080,7 +11084,7 @@ exports.validateDistros = validateDistros;
 /**
  * Install ROS dependencies for given packages in the workspace, for all ROS distros being used.
  */
-function installRosdeps(packageSelection, workspaceDir, ros1Distro, ros2Distro) {
+function installRosdeps(packageSelection, workspaceDir, commandPrefix, ros1Distro, ros2Distro) {
     return __awaiter(this, void 0, void 0, function* () {
         const scriptName = "install_rosdeps.sh";
         const scriptPath = path.join(workspaceDir, scriptName);
@@ -11100,10 +11104,10 @@ function installRosdeps(packageSelection, workspaceDir, ros1Distro, ros2Distro) 
         let exitCode = 0;
         const options = { cwd: workspaceDir };
         if (ros1Distro) {
-            exitCode += yield execBashCommand(`./${scriptName} ${ros1Distro}`, "", options);
+            exitCode += yield execBashCommand(`./${scriptName} ${ros1Distro}`, commandPrefix, options);
         }
         if (ros2Distro) {
-            exitCode += yield execBashCommand(`./${scriptName} ${ros2Distro}`, "", options);
+            exitCode += yield execBashCommand(`./${scriptName} ${ros2Distro}`, commandPrefix, options);
         }
         return exitCode;
     });
@@ -11295,11 +11299,36 @@ done`;
         yield execBashCommand("vcs import --force --recursive src/ < package.repo", undefined, options);
         // Print HEAD commits of all repos
         yield execBashCommand("vcs log -l1 src/", undefined, options);
+        // Source any installed ROS distributions if they are present
+        let sourceCommandPrefix = "";
+        if (isLinux) {
+            if (targetRos1Distro) {
+                const ros1SetupPath = `/opt/ros/${targetRos1Distro}/setup.sh`;
+                if (fs_1.default.existsSync(ros1SetupPath)) {
+                    sourceCommandPrefix += `source ${ros1SetupPath} && `;
+                }
+            }
+            if (targetRos2Distro) {
+                const ros2SetupPath = `/opt/ros/${targetRos2Distro}/setup.sh`;
+                if (fs_1.default.existsSync(ros2SetupPath)) {
+                    sourceCommandPrefix += `source ${ros2SetupPath} && `;
+                }
+            }
+        }
+        else if (isWindows) {
+            // Windows only supports ROS2
+            if (targetRos2Distro) {
+                const ros2SetupPath = `c:/dev/${targetRos2Distro}/ros2-windows/setup.bat`;
+                if (fs_1.default.existsSync(ros2SetupPath)) {
+                    sourceCommandPrefix += `${ros2SetupPath} && `;
+                }
+            }
+        }
         if (isLinux) {
             // Always update APT before installing packages on Ubuntu
             yield execBashCommand("sudo apt-get update");
         }
-        yield installRosdeps(buildPackageSelection, rosWorkspaceDir, targetRos1Distro, targetRos2Distro);
+        yield installRosdeps(buildPackageSelection, rosWorkspaceDir, sourceCommandPrefix, targetRos1Distro, targetRos2Distro);
         if (colconDefaults.includes(`"mixin"`) && colconMixinRepo !== "") {
             yield execBashCommand(`colcon mixin add default '${colconMixinRepo}'`, undefined, options);
             yield execBashCommand("colcon mixin update default", undefined, options);
@@ -11322,31 +11351,6 @@ done`;
         // ament_cmake should handle this automatically, but we are seeing cases
         // where this does not happen. See issue #26 for relevant CI logs.
         core.addPath(path.join(rosWorkspaceDir, "install", "bin"));
-        // Source any installed ROS distributions if they are present
-        let colconCommandPrefix = "";
-        if (isLinux) {
-            if (targetRos1Distro) {
-                const ros1SetupPath = `/opt/ros/${targetRos1Distro}/setup.sh`;
-                if (fs_1.default.existsSync(ros1SetupPath)) {
-                    colconCommandPrefix += `source ${ros1SetupPath} && `;
-                }
-            }
-            if (targetRos2Distro) {
-                const ros2SetupPath = `/opt/ros/${targetRos2Distro}/setup.sh`;
-                if (fs_1.default.existsSync(ros2SetupPath)) {
-                    colconCommandPrefix += `source ${ros2SetupPath} && `;
-                }
-            }
-        }
-        else if (isWindows) {
-            // Windows only supports ROS2
-            if (targetRos2Distro) {
-                const ros2SetupPath = `c:/dev/${targetRos2Distro}/ros2-windows/setup.bat`;
-                if (fs_1.default.existsSync(ros2SetupPath)) {
-                    colconCommandPrefix += `${ros2SetupPath} && `;
-                }
-            }
-        }
         let colconBuildCmd = filterNonEmptyJoin([
             `colcon build`,
             `--event-handlers console_cohesion+`,
@@ -11357,6 +11361,7 @@ done`;
         if (!isWindows) {
             colconBuildCmd = colconBuildCmd.concat(" --symlink-install");
         }
+        const colconCommandPrefix = sourceCommandPrefix;
         yield execBashCommand(colconBuildCmd, colconCommandPrefix, options);
         if (!skipTests) {
             yield runTests(colconCommandPrefix, options, testPackageSelection, extra_options, coverageIgnorePattern);


### PR DESCRIPTION
As I've found the current implementation can't support dependencies with conditions like `<depend condition="$ROS_VERSION == 2">`, I added `commandPrefix` to `installRosdeps()`.

The followings are my test results.

1. Not working with the current implementation
    - https://github.com/kenji-miyake/action-ros-ci-test-condition/pull/1
2. Fixed with this PR
    - https://github.com/kenji-miyake/action-ros-ci-test-condition/pull/4

FYI: There is no problem with `ROS_PYTHON_VERSION` conditions even with the current implementation.
- https://github.com/kenji-miyake/action-ros-ci-test-condition/pull/2
    - Passed
- https://github.com/kenji-miyake/action-ros-ci-test-condition/pull/3
    - Failed as expeced