### PR TITLE
Add ROS environment variables to options

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -11084,7 +11084,7 @@ exports.validateDistros = validateDistros;
 /**
  * Install ROS dependencies for given packages in the workspace, for all ROS distros being used.
  */
-function installRosdeps(packageSelection, workspaceDir, ros1Distro, ros2Distro) {
+function installRosdeps(packageSelection, workspaceDir, options, ros1Distro, ros2Distro) {
     return __awaiter(this, void 0, void 0, function* () {
         const scriptName = "install_rosdeps.sh";
         const scriptPath = path.join(workspaceDir, scriptName);
@@ -11102,7 +11102,6 @@ function installRosdeps(packageSelection, workspaceDir, ros1Distro, ros2Distro) 
 	rosdep install -r --from-paths $package_paths --ignore-src --skip-keys rti-connext-dds-5.3.1 --rosdistro $DISTRO -y || true`;
         fs_1.default.writeFileSync(scriptPath, scriptContent, { mode: 0o766 });
         let exitCode = 0;
-        const options = { cwd: workspaceDir };
         if (ros1Distro) {
             exitCode += yield execBashCommand(`./${scriptName} ${ros1Distro}`, "", options);
         }
@@ -11231,9 +11230,10 @@ function run_throw() {
         yield io.mkdirP(rosWorkspaceDir + "/src");
         const options = {
             cwd: rosWorkspaceDir,
+            env: Object.assign(Object.assign({}, process.env), { ROS_VERSION: targetRos1Distro ? "1" : "2", ROS_PYTHON_VERSION: targetRos1Distro && targetRos1Distro != "noetic" ? "2" : "3" }),
         };
         if (colconDefaultsFile !== "") {
-            options.env = Object.assign(Object.assign({}, process.env), { COLCON_DEFAULTS_FILE: colconDefaultsFile });
+            options.env = Object.assign(Object.assign({}, options.env), { COLCON_DEFAULTS_FILE: colconDefaultsFile });
         }
         if (importToken !== "") {
             // Unset all local extraheader config entries possibly set by actions/checkout,
@@ -11303,7 +11303,7 @@ done`;
             // Always update APT before installing packages on Ubuntu
             yield execBashCommand("sudo apt-get update");
         }
-        yield installRosdeps(buildPackageSelection, rosWorkspaceDir, targetRos1Distro, targetRos2Distro);
+        yield installRosdeps(buildPackageSelection, rosWorkspaceDir, options, targetRos1Distro, targetRos2Distro);
         if (colconDefaults.includes(`"mixin"`) && colconMixinRepo !== "") {
             yield execBashCommand(`colcon mixin add default '${colconMixinRepo}'`, undefined, options);
             yield execBashCommand("colcon mixin update default", undefined, options);

--- a/dist/index.js
+++ b/dist/index.js
@@ -1906,6 +1906,25 @@ exports.checkBypass = checkBypass;
 
 "use strict";
 
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    Object.defineProperty(o, k2, { enumerable: true, get: function() { return m[k]; } });
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (k !== "default" && Object.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    __setModuleDefault(result, mod);
+    return result;
+};
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -1915,16 +1934,9 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
         step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
 };
-var __importStar = (this && this.__importStar) || function (mod) {
-    if (mod && mod.__esModule) return mod;
-    var result = {};
-    if (mod != null) for (var k in mod) if (Object.hasOwnProperty.call(mod, k)) result[k] = mod[k];
-    result["default"] = mod;
-    return result;
-};
 var _a;
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-const assert_1 = __nccwpck_require__(2357);
+exports.getCmdPath = exports.tryGetExecutablePath = exports.isRooted = exports.isDirectory = exports.exists = exports.IS_WINDOWS = exports.unlink = exports.symlink = exports.stat = exports.rmdir = exports.rename = exports.readlink = exports.readdir = exports.mkdir = exports.lstat = exports.copyFile = exports.chmod = void 0;
 const fs = __importStar(__nccwpck_require__(5747));
 const path = __importStar(__nccwpck_require__(5622));
 _a = fs.promises, exports.chmod = _a.chmod, exports.copyFile = _a.copyFile, exports.lstat = _a.lstat, exports.mkdir = _a.mkdir, exports.readdir = _a.readdir, exports.readlink = _a.readlink, exports.rename = _a.rename, exports.rmdir = _a.rmdir, exports.stat = _a.stat, exports.symlink = _a.symlink, exports.unlink = _a.unlink;
@@ -1967,49 +1979,6 @@ function isRooted(p) {
     return p.startsWith('/');
 }
 exports.isRooted = isRooted;
-/**
- * Recursively create a directory at `fsPath`.
- *
- * This implementation is optimistic, meaning it attempts to create the full
- * path first, and backs up the path stack from there.
- *
- * @param fsPath The path to create
- * @param maxDepth The maximum recursion depth
- * @param depth The current recursion depth
- */
-function mkdirP(fsPath, maxDepth = 1000, depth = 1) {
-    return __awaiter(this, void 0, void 0, function* () {
-        assert_1.ok(fsPath, 'a path argument must be provided');
-        fsPath = path.resolve(fsPath);
-        if (depth >= maxDepth)
-            return exports.mkdir(fsPath);
-        try {
-            yield exports.mkdir(fsPath);
-            return;
-        }
-        catch (err) {
-            switch (err.code) {
-                case 'ENOENT': {
-                    yield mkdirP(path.dirname(fsPath), maxDepth, depth + 1);
-                    yield exports.mkdir(fsPath);
-                    return;
-                }
-                default: {
-                    let stats;
-                    try {
-                        stats = yield exports.stat(fsPath);
-                    }
-                    catch (err2) {
-                        throw err;
-                    }
-                    if (!stats.isDirectory())
-                        throw err;
-                }
-            }
-        }
-    });
-}
-exports.mkdirP = mkdirP;
 /**
  * Best effort attempt to determine whether a file exists and is executable.
  * @param filePath    file path to check
@@ -2106,6 +2075,12 @@ function isUnixExecutable(stats) {
         ((stats.mode & 8) > 0 && stats.gid === process.getgid()) ||
         ((stats.mode & 64) > 0 && stats.uid === process.getuid()));
 }
+// Get the path of cmd.exe in windows
+function getCmdPath() {
+    var _a;
+    return (_a = process.env['COMSPEC']) !== null && _a !== void 0 ? _a : `cmd.exe`;
+}
+exports.getCmdPath = getCmdPath;
 //# sourceMappingURL=io-util.js.map
 
 /***/ }),
@@ -2115,6 +2090,25 @@ function isUnixExecutable(stats) {
 
 "use strict";
 
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    Object.defineProperty(o, k2, { enumerable: true, get: function() { return m[k]; } });
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (k !== "default" && Object.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    __setModuleDefault(result, mod);
+    return result;
+};
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -2124,19 +2118,15 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
         step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
 };
-var __importStar = (this && this.__importStar) || function (mod) {
-    if (mod && mod.__esModule) return mod;
-    var result = {};
-    if (mod != null) for (var k in mod) if (Object.hasOwnProperty.call(mod, k)) result[k] = mod[k];
-    result["default"] = mod;
-    return result;
-};
 Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.findInPath = exports.which = exports.mkdirP = exports.rmRF = exports.mv = exports.cp = void 0;
+const assert_1 = __nccwpck_require__(2357);
 const childProcess = __importStar(__nccwpck_require__(3129));
 const path = __importStar(__nccwpck_require__(5622));
 const util_1 = __nccwpck_require__(1669);
 const ioUtil = __importStar(__nccwpck_require__(1962));
 const exec = util_1.promisify(childProcess.exec);
+const execFile = util_1.promisify(childProcess.execFile);
 /**
  * Copies a file or folder.
  * Based off of shelljs - https://github.com/shelljs/shelljs/blob/9237f66c52e5daa40458f94f9565e18e8132f5a6/src/cp.js
@@ -2147,14 +2137,14 @@ const exec = util_1.promisify(childProcess.exec);
  */
 function cp(source, dest, options = {}) {
     return __awaiter(this, void 0, void 0, function* () {
-        const { force, recursive } = readCopyOptions(options);
+        const { force, recursive, copySourceDirectory } = readCopyOptions(options);
         const destStat = (yield ioUtil.exists(dest)) ? yield ioUtil.stat(dest) : null;
         // Dest is an existing file, but not forcing
         if (destStat && destStat.isFile() && !force) {
             return;
         }
         // If dest is an existing directory, should copy inside.
-        const newDest = destStat && destStat.isDirectory()
+        const newDest = destStat && destStat.isDirectory() && copySourceDirectory
             ? path.join(dest, path.basename(source))
             : dest;
         if (!(yield ioUtil.exists(source))) {
@@ -2219,12 +2209,22 @@ function rmRF(inputPath) {
         if (ioUtil.IS_WINDOWS) {
             // Node doesn't provide a delete operation, only an unlink function. This means that if the file is being used by another
             // program (e.g. antivirus), it won't be deleted. To address this, we shell out the work to rd/del.
+            // Check for invalid characters
+            // https://docs.microsoft.com/en-us/windows/win32/fileio/naming-a-file
+            if (/[*"<>|]/.test(inputPath)) {
+                throw new Error('File path must not contain `*`, `"`, `<`, `>` or `|` on Windows');
+            }
             try {
+                const cmdPath = ioUtil.getCmdPath();
                 if (yield ioUtil.isDirectory(inputPath, true)) {
-                    yield exec(`rd /s /q "${inputPath}"`);
+                    yield exec(`${cmdPath} /s /c "rd /s /q "%inputPath%""`, {
+                        env: { inputPath }
+                    });
                 }
                 else {
-                    yield exec(`del /f /a "${inputPath}"`);
+                    yield exec(`${cmdPath} /s /c "del /f /a "%inputPath%""`, {
+                        env: { inputPath }
+                    });
                 }
             }
             catch (err) {
@@ -2257,7 +2257,7 @@ function rmRF(inputPath) {
                 return;
             }
             if (isDir) {
-                yield exec(`rm -rf "${inputPath}"`);
+                yield execFile(`rm`, [`-rf`, `${inputPath}`]);
             }
             else {
                 yield ioUtil.unlink(inputPath);
@@ -2275,7 +2275,8 @@ exports.rmRF = rmRF;
  */
 function mkdirP(fsPath) {
     return __awaiter(this, void 0, void 0, function* () {
-        yield ioUtil.mkdirP(fsPath);
+        assert_1.ok(fsPath, 'a path argument must be provided');
+        yield ioUtil.mkdir(fsPath, { recursive: true });
     });
 }
 exports.mkdirP = mkdirP;
@@ -2373,7 +2374,10 @@ exports.findInPath = findInPath;
 function readCopyOptions(options) {
     const force = options.force == null ? true : options.force;
     const recursive = Boolean(options.recursive);
-    return { force, recursive };
+    const copySourceDirectory = options.copySourceDirectory == null
+        ? true
+        : Boolean(options.copySourceDirectory);
+    return { force, recursive, copySourceDirectory };
 }
 function cpDirRecursive(sourceDir, destDir, currentDepth, force) {
     return __awaiter(this, void 0, void 0, function* () {

--- a/dist/index.js
+++ b/dist/index.js
@@ -11230,7 +11230,9 @@ function run_throw() {
         yield io.mkdirP(rosWorkspaceDir + "/src");
         const options = {
             cwd: rosWorkspaceDir,
-            env: Object.assign(Object.assign({}, process.env), { ROS_VERSION: targetRos1Distro ? "1" : "2", ROS_PYTHON_VERSION: targetRos1Distro && targetRos1Distro != "noetic" ? "2" : "3" }),
+            env: Object.assign(Object.assign({}, process.env), { ROS_VERSION: targetRos2Distro ? "2" : "1", ROS_PYTHON_VERSION: targetRos2Distro || (targetRos1Distro && targetRos1Distro == "noetic")
+                    ? "3"
+                    : "2" }),
         };
         if (colconDefaultsFile !== "") {
             options.env = Object.assign(Object.assign({}, options.env), { COLCON_DEFAULTS_FILE: colconDefaultsFile });

--- a/src/action-ros-ci.ts
+++ b/src/action-ros-ci.ts
@@ -359,9 +359,11 @@ async function run_throw(): Promise<void> {
 		cwd: rosWorkspaceDir,
 		env: {
 			...process.env,
-			ROS_VERSION: targetRos1Distro ? "1" : "2",
+			ROS_VERSION: targetRos2Distro ? "2" : "1",
 			ROS_PYTHON_VERSION:
-				targetRos1Distro && targetRos1Distro != "noetic" ? "2" : "3",
+				targetRos2Distro || (targetRos1Distro && targetRos1Distro == "noetic")
+					? "3"
+					: "2",
 		},
 	};
 	if (colconDefaultsFile !== "") {

--- a/src/action-ros-ci.ts
+++ b/src/action-ros-ci.ts
@@ -156,6 +156,7 @@ export function validateDistros(
 async function installRosdeps(
 	packageSelection: string,
 	workspaceDir: string,
+	options: im.ExecOptions,
 	ros1Distro?: string,
 	ros2Distro?: string
 ): Promise<number> {
@@ -176,7 +177,6 @@ async function installRosdeps(
 	fs.writeFileSync(scriptPath, scriptContent, { mode: 0o766 });
 
 	let exitCode = 0;
-	const options = { cwd: workspaceDir };
 	if (ros1Distro) {
 		exitCode += await execBashCommand(
 			`./${scriptName} ${ros1Distro}`,
@@ -357,10 +357,16 @@ async function run_throw(): Promise<void> {
 
 	const options: im.ExecOptions = {
 		cwd: rosWorkspaceDir,
+		env: {
+			...process.env,
+			ROS_VERSION: targetRos1Distro ? "1" : "2",
+			ROS_PYTHON_VERSION:
+				targetRos1Distro && targetRos1Distro != "noetic" ? "2" : "3",
+		},
 	};
 	if (colconDefaultsFile !== "") {
 		options.env = {
-			...process.env,
+			...options.env,
 			COLCON_DEFAULTS_FILE: colconDefaultsFile,
 		};
 	}
@@ -472,6 +478,7 @@ done`;
 	await installRosdeps(
 		buildPackageSelection,
 		rosWorkspaceDir,
+		options,
 		targetRos1Distro,
 		targetRos2Distro
 	);


### PR DESCRIPTION
Refinement of #697

In order to support dependencies with conditions like `<depend condition="$ROS_VERSION == 2">`, I added `ROS_VERSION` and `ROS_PYTHON_VERSION` in `install_rosdeps.sh`.

The followings are my test results.

|                                                               | Current Implementation                                                     | This PR                                                                                   |
| ------------------------------------------------------------- | -------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
| 1. Docker Image                                               | :x: <https://github.com/kenji-miyake/action-ros-ci-test-condition/pull/1>  | :heavy_check_mark: <https://github.com/kenji-miyake/action-ros-ci-test-condition/pull/16> |
| 2. setup-ros                                                  | :x: <https://github.com/kenji-miyake/action-ros-ci-test-condition/pull/6>  | :heavy_check_mark: <https://github.com/kenji-miyake/action-ros-ci-test-condition/pull/17> |
| 3. Source Build<br>(condition-dependency isn't in ros2.repos) | :x: <https://github.com/kenji-miyake/action-ros-ci-test-condition/pull/11> | :heavy_check_mark: <https://github.com/kenji-miyake/action-ros-ci-test-condition/pull/18> |
| 4. Source Build<br>(condition-dependency is in ros2.repos)    | :x: <https://github.com/kenji-miyake/action-ros-ci-test-condition/pull/20> | :heavy_check_mark: <https://github.com/kenji-miyake/action-ros-ci-test-condition/pull/21> |

The difference between `3` and `4` is whether the environment variables are required in the `rosdep install` step. `3` requires and `4` doesn't.

Note: In some PRs, `rolling` test is failed, but it's not related to this PR.