### PR TITLE
Add DEBIAN_FRONTEND=noninteractive in Linux

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -11237,6 +11237,9 @@ function run_throw() {
         if (colconDefaultsFile !== "") {
             options.env = Object.assign(Object.assign({}, options.env), { COLCON_DEFAULTS_FILE: colconDefaultsFile });
         }
+        if (isLinux) {
+            options.env = Object.assign(Object.assign({}, options.env), { DEBIAN_FRONTEND: "noninteractive" });
+        }
         if (importToken !== "") {
             // Unset all local extraheader config entries possibly set by actions/checkout,
             // because local settings take precedence and the default token used by

--- a/src/action-ros-ci.ts
+++ b/src/action-ros-ci.ts
@@ -372,6 +372,12 @@ async function run_throw(): Promise<void> {
 			COLCON_DEFAULTS_FILE: colconDefaultsFile,
 		};
 	}
+	if (isLinux) {
+		options.env = {
+			...options.env,
+			DEBIAN_FRONTEND: "noninteractive",
+		};
+	}
 
 	if (importToken !== "") {
 		// Unset all local extraheader config entries possibly set by actions/checkout,


### PR DESCRIPTION
I found `action-ros-ci` will freeze when there are some interactive packages in dependencies.
https://github.com/kenji-miyake/grid_map/pull/1/checks?check_run_id=3324912225
![image](https://user-images.githubusercontent.com/31987104/129409506-daee9277-dc6a-4f54-942e-4ca4ad25202d.png)

So I added `DEBIAN_FRONTEND=noninteractive` in Linux and tested it below.
https://github.com/kenji-miyake/grid_map/pull/2/checks?check_run_id=3325170640

![image](https://user-images.githubusercontent.com/31987104/129409767-53baeca1-fe55-4f82-82cc-5891351be522.png)

Note: This PR is based on #700. I will rebase this PR after #700 is merged.