### PR TITLE
Fix Windows Build Functionality

### DIFF
--- a/.github/workflows/repo_file_for_test_cpp_package.repos
+++ b/.github/workflows/repo_file_for_test_cpp_package.repos
@@ -1,10 +1,10 @@
 # repo file only containing osrf_testing_tools_cpp
 # This repository has been chosen because it does depend on anything, as of
-# 1.2.1.
+# 1.3.4.
 #
 # https://github.com/ament/ament_lint/tree/0.8.1
 repositories:
   osrf_testing_tools_cpp:
     type: git
     url: https://github.com/osrf/osrf_testing_tools_cpp.git
-    version: 1.2.1
+    version: 1.3.4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -101,14 +101,8 @@ jobs:
         with:
           target-ros2-distro: ${{ matrix.ros_distribution }}
           vcs-repo-file-url: "${{ github.workspace }}/.github/workflows/repo_file_for_test_cpp_package.repos"
-        # TODO(tmoulard): re-enable this test once it passes on Windows
-        if: runner.os != 'Windows'
       - run: test -d "${{ steps.test_all_packages_in_repo.outputs.ros-workspace-directory-name }}/install/osrf_testing_tools_cpp"
-        # TODO(tmoulard): re-enable this test once it passes on Windows
-        if: runner.os != 'Windows'
       - run: test -d "${{ steps.test_all_packages_in_repo.outputs.ros-workspace-directory-name }}/install/test_osrf_testing_tools_cpp"
-        # TODO(tmoulard): re-enable this test once it passes on Windows
-        if: runner.os != 'Windows'
 
   test_ros2_foxy_package_with_dependencies:
     name: "Test ROS 2 foxy package with ROS dependencies"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -102,7 +102,17 @@ jobs:
           target-ros2-distro: ${{ matrix.ros_distribution }}
           vcs-repo-file-url: "${{ github.workspace }}/.github/workflows/repo_file_for_test_cpp_package.repos"
       - run: test -d "${{ steps.test_all_packages_in_repo.outputs.ros-workspace-directory-name }}/install/osrf_testing_tools_cpp"
+        name: "Check that ament_copyright install directory is present (Non-Windows only)"
+        if: matrix.os != 'windows-latest'
+      - run: test -d "${{ steps.test_all_packages_in_repo.outputs.ros-workspace-directory-name }}/install/share/osrf_testing_tools_cpp"
+        name: "Check that ament_copyright install directory is present in merged install space (Windows only)"
+        if: matrix.os == 'windows-latest'
       - run: test -d "${{ steps.test_all_packages_in_repo.outputs.ros-workspace-directory-name }}/install/test_osrf_testing_tools_cpp"
+        name: "Check that ament_copyright install directory is present (Non-Windows only)"
+        if: matrix.os != 'windows-latest'
+      - run: test -d "${{ steps.test_all_packages_in_repo.outputs.ros-workspace-directory-name }}/install/share/test_osrf_testing_tools_cpp"
+        name: "Check that ament_copyright install directory is present in merged install space (Windows only)"
+        if: matrix.os == 'windows-latest'
 
   test_ros2_foxy_package_with_dependencies:
     name: "Test ROS 2 foxy package with ROS dependencies"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,6 +86,9 @@ jobs:
       matrix:
         os: [macOS-latest, windows-latest]
         ros_distribution: [foxy, galactic]
+    env: 
+      INSTALL_TYPE: ${{ matrix.os == 'windows-latest' && 'merged' || 'default' }}
+      INSTALL_PATH: ${{ matrix.os == 'windows-latest' && 'install/share' || 'install' }}
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2.4.0
@@ -101,18 +104,11 @@ jobs:
         with:
           target-ros2-distro: ${{ matrix.ros_distribution }}
           vcs-repo-file-url: "${{ github.workspace }}/.github/workflows/repo_file_for_test_cpp_package.repos"
-      - run: test -d "${{ steps.test_all_packages_in_repo.outputs.ros-workspace-directory-name }}/install/osrf_testing_tools_cpp"
-        name: "Check that ament_copyright install directory is present (Non-Windows only)"
-        if: matrix.os != 'windows-latest'
-      - run: test -d "${{ steps.test_all_packages_in_repo.outputs.ros-workspace-directory-name }}/install/share/osrf_testing_tools_cpp"
-        name: "Check that ament_copyright install directory is present in merged install space (Windows only)"
-        if: matrix.os == 'windows-latest'
-      - run: test -d "${{ steps.test_all_packages_in_repo.outputs.ros-workspace-directory-name }}/install/test_osrf_testing_tools_cpp"
-        name: "Check that ament_copyright install directory is present (Non-Windows only)"
-        if: matrix.os != 'windows-latest'
-      - run: test -d "${{ steps.test_all_packages_in_repo.outputs.ros-workspace-directory-name }}/install/share/test_osrf_testing_tools_cpp"
-        name: "Check that ament_copyright install directory is present in merged install space (Windows only)"
-        if: matrix.os == 'windows-latest'
+      - name: "Check that osrf_testing_tools_cpp install directory is present in ${{ env.INSTALL_TYPE }} install space"
+        run: test -d "${{ steps.test_all_packages_in_repo.outputs.ros-workspace-directory-name }}/${{ env.INSTALL_PATH }}/osrf_testing_tools_cpp"
+      - name: "Check that test_osrf_testing_tools_cpp install directory is present in ${{ env.INSTALL_TYPE }} install space"
+        run: test -d "${{ steps.test_all_packages_in_repo.outputs.ros-workspace-directory-name }}/${{ env.INSTALL_PATH }}/test_osrf_testing_tools_cpp"
+        
 
   test_ros2_foxy_package_with_dependencies:
     name: "Test ROS 2 foxy package with ROS dependencies"
@@ -210,6 +206,8 @@ jobs:
         ros_distribution: [foxy, galactic, rolling]
     env:
       DISTRO_REPOS_URL: "https://raw.githubusercontent.com/ros2/ros2/${{ matrix.ros_distribution == 'rolling' && 'master' || matrix.ros_distribution }}/ros2.repos"
+      INSTALL_TYPE: ${{ matrix.os == 'windows-latest' && 'merged' || 'default' }}
+      INSTALL_PATH: ${{ matrix.os == 'windows-latest' && 'install/share' || 'install' }}
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2.4.0
@@ -224,13 +222,8 @@ jobs:
           package-name: ament_copyright
           target-ros2-distro: ${{ matrix.ros_distribution }}
           vcs-repo-file-url: ${{ env.DISTRO_REPOS_URL }}
-      - run: test -d "${{ steps.test_single_package.outputs.ros-workspace-directory-name }}/install/ament_copyright"
-        name: "Check that ament_copyright install directory is present (Non-Windows only)"
-        if: matrix.os != 'windows-latest'
-      - run: test -d "${{ steps.test_single_package.outputs.ros-workspace-directory-name }}/install/share/ament_copyright"
-        name: "Check that ament_copyright install directory is present in merged install space (Windows only)"
-        if: matrix.os == 'windows-latest'
-
+      - name: "Check that ament_copyright install directory is present in ${{ env.INSTALL_TYPE }} install space"
+        run: test -d "${{ steps.test_single_package.outputs.ros-workspace-directory-name }}/${{ env.INSTALL_PATH }}/ament_copyright"
       - uses: ./
         id: test_multiple_packages
         name: "Test multiple package, default options"
@@ -238,19 +231,10 @@ jobs:
           package-name: ament_copyright ament_lint
           target-ros2-distro: ${{ matrix.ros_distribution }}
           vcs-repo-file-url: ${{ env.DISTRO_REPOS_URL }}
-      - run: test -d "${{ steps.test_multiple_packages.outputs.ros-workspace-directory-name }}/install/ament_copyright"
-        name: "Check that ament_copyright install directory is present (Non-Windows only)"
-        if: matrix.os != 'windows-latest'
-      - run: test -d "${{ steps.test_multiple_packages.outputs.ros-workspace-directory-name }}/install/share/ament_copyright"
-        name: "Check that ament_copyright install directory is present in merged install space (Windows only)"
-        if: matrix.os == 'windows-latest'
-      - run: test -d "${{ steps.test_multiple_packages.outputs.ros-workspace-directory-name }}/install/ament_lint"
-        name: "Check that ament_lint install directory is present (Non-Windows only)"
-        if: matrix.os != 'windows-latest'
-      - run: test -d "${{ steps.test_multiple_packages.outputs.ros-workspace-directory-name }}/install/share/ament_lint"
-        name: "Check that ament_lint install directory is present in merged install space (Windows only)"
-        if: matrix.os == 'windows-latest'
-
+      - name: "Check that ament_copyright install directory is present in ${{ env.INSTALL_TYPE }} install space"
+        run: test -d "${{ steps.test_multiple_packages.outputs.ros-workspace-directory-name }}/${{ env.INSTALL_PATH }}/ament_copyright"
+      - name: "Check that ament_lint install directory is present in ${{ env.INSTALL_TYPE }} install space"
+        run: test -d "${{ steps.test_multiple_packages.outputs.ros-workspace-directory-name }}/${{ env.INSTALL_PATH }}/ament_lint"
       - uses: ./
         id: test_connext_dependency
         name: "Test single package with Connext dependency, default options"
@@ -277,13 +261,8 @@ jobs:
           package-name: ament_copyright
           target-ros2-distro: ${{ matrix.ros_distribution }}
           vcs-repo-file-url: ${{ env.DISTRO_REPOS_URL }}
-      - run: test -d "${{ steps.test_mixin.outputs.ros-workspace-directory-name }}/install/ament_copyright"
-        name: "Check that ament_copyright install directory is present (Non-Windows only)"
-        if: matrix.os != 'windows-latest'
-      - run: test -d "${{ steps.test_mixin.outputs.ros-workspace-directory-name }}/install/share/ament_copyright"
-        name: "Check that ament_copyright install directory is present in merged install space (Windows only)"
-        if: matrix.os == 'windows-latest'
-
+      - name: "Check that ament_copyright install directory is present in ${{ env.INSTALL_TYPE }} install space"
+        run: test -d "${{ steps.test_mixin.outputs.ros-workspace-directory-name }}/${{ env.INSTALL_PATH }}/ament_copyright"
       - uses: ./
         id: test_repo
         name: "Test single package, with custom repository file"
@@ -291,13 +270,8 @@ jobs:
           vcs-repo-file-url: "${{ github.workspace }}/.github/workflows/repo_file_for_test.repos"
           package-name: ament_copyright
           target-ros2-distro: ${{ matrix.ros_distribution }}
-      - run: test -d "${{ steps.test_repo.outputs.ros-workspace-directory-name }}/install/ament_copyright"
-        name: "Check that ament_copyright install directory is present (Non-Windows only)"
-        if: matrix.os != 'windows-latest'
-      - run: test -d "${{ steps.test_repo.outputs.ros-workspace-directory-name }}/install/share/ament_copyright"
-        name: "Check that ament_copyright install directory is present in merged install space (Windows only)"
-        if: matrix.os == 'windows-latest'
-
+      - name: "Check that ament_copyright install directory is present in ${{ env.INSTALL_TYPE }} install space"
+        run: test -d "${{ steps.test_repo.outputs.ros-workspace-directory-name }}/${{ env.INSTALL_PATH }}/ament_copyright"
       - uses: ./
         id: test_colcon_defaults
         name: "Test single package, with colcon defaults"
@@ -311,12 +285,8 @@ jobs:
           package-name: ament_copyright
           target-ros2-distro: ${{ matrix.ros_distribution }}
           vcs-repo-file-url: ${{ env.DISTRO_REPOS_URL }}
-      - run: test -d "${{ steps.test_colcon_defaults.outputs.ros-workspace-directory-name }}/install/ament_copyright"
-        name: "Check that ament_copyright install directory is present (Non-Windows only)"
-        if: matrix.os != 'windows-latest'
-      - run: test -d "${{ steps.test_colcon_defaults.outputs.ros-workspace-directory-name }}/install/share/ament_copyright"
-        name: "Check that ament_copyright install directory is present in merged install space (Windows only)"
-        if: matrix.os == 'windows-latest'
+      - name: "Check that ament_copyright install directory is present in ${{ env.INSTALL_TYPE }} install space"
+        run: test -d "${{ steps.test_colcon_defaults.outputs.ros-workspace-directory-name }}/${{ env.INSTALL_PATH }}/ament_copyright"
       - run: test -d "${{ steps.test_colcon_defaults.outputs.ros-workspace-directory-name }}/build-custom"
 
       # The second repo file is ignored, but will get vcs-import'ed anyway.
@@ -331,12 +301,8 @@ jobs:
             .github/workflows/repo_file_for_test_cpp_package.repos
           package-name: ament_copyright
           target-ros2-distro: ${{ matrix.ros_distribution }}
-      - run: test -d "${{ steps.test_multiple_repos.outputs.ros-workspace-directory-name }}/install/ament_copyright"
-        name: "Check that ament_copyright install directory is present (Non-Windows only)"
-        if: matrix.os != 'windows-latest'
-      - run: test -d "${{ steps.test_multiple_repos.outputs.ros-workspace-directory-name }}/install/share/ament_copyright"
-        name: "Check that ament_copyright install directory is present in merged install space (Windows only)"
-        if: matrix.os == 'windows-latest'
+      - name: "Check that ament_copyright install directory is present in ${{ env.INSTALL_TYPE }} install space"
+        run: test -d "${{ steps.test_multiple_repos.outputs.ros-workspace-directory-name }}/${{ env.INSTALL_PATH }}/ament_copyright"
       - run: test -d "${{ steps.test_multiple_repos.outputs.ros-workspace-directory-name }}/src/ament_lint"
       - run: test -d "${{ steps.test_multiple_repos.outputs.ros-workspace-directory-name }}/src/osrf_testing_tools_cpp"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -221,7 +221,11 @@ jobs:
           target-ros2-distro: ${{ matrix.ros_distribution }}
           vcs-repo-file-url: ${{ env.DISTRO_REPOS_URL }}
       - run: test -d "${{ steps.test_single_package.outputs.ros-workspace-directory-name }}/install/ament_copyright"
-        name: "Check that ament_copyright install directory is present"
+        name: "Check that ament_copyright install directory is present (Non-Windows only)"
+        if: matrix.os != 'windows-latest'
+      - run: test -d "${{ steps.test_single_package.outputs.ros-workspace-directory-name }}/install/share/ament_copyright"
+        name: "Check that ament_copyright install directory is present in merged install space (Windows only)"
+        if: matrix.os == 'windows-latest'
 
       - uses: ./
         id: test_multiple_packages
@@ -231,9 +235,17 @@ jobs:
           target-ros2-distro: ${{ matrix.ros_distribution }}
           vcs-repo-file-url: ${{ env.DISTRO_REPOS_URL }}
       - run: test -d "${{ steps.test_multiple_packages.outputs.ros-workspace-directory-name }}/install/ament_copyright"
-        name: "Check that ament_copyright install directory is present"
+        name: "Check that ament_copyright install directory is present (Non-Windows only)"
+        if: matrix.os != 'windows-latest'
+      - run: test -d "${{ steps.test_multiple_packages.outputs.ros-workspace-directory-name }}/install/share/ament_copyright"
+        name: "Check that ament_copyright install directory is present in merged install space (Windows only)"
+        if: matrix.os == 'windows-latest'
       - run: test -d "${{ steps.test_multiple_packages.outputs.ros-workspace-directory-name }}/install/ament_lint"
-        name: "Check that ament_lint install directory is present"
+        name: "Check that ament_lint install directory is present (Non-Windows only)"
+        if: matrix.os != 'windows-latest'
+      - run: test -d "${{ steps.test_multiple_packages.outputs.ros-workspace-directory-name }}/install/share/ament_lint"
+        name: "Check that ament_lint install directory is present in merged install space (Windows only)"
+        if: matrix.os == 'windows-latest'
 
       - uses: ./
         id: test_connext_dependency
@@ -262,7 +274,11 @@ jobs:
           target-ros2-distro: ${{ matrix.ros_distribution }}
           vcs-repo-file-url: ${{ env.DISTRO_REPOS_URL }}
       - run: test -d "${{ steps.test_mixin.outputs.ros-workspace-directory-name }}/install/ament_copyright"
-        name: "Check that ament_copyright install directory is present"
+        name: "Check that ament_copyright install directory is present (Non-Windows only)"
+        if: matrix.os != 'windows-latest'
+      - run: test -d "${{ steps.test_mixin.outputs.ros-workspace-directory-name }}/install/share/ament_copyright"
+        name: "Check that ament_copyright install directory is present in merged install space (Windows only)"
+        if: matrix.os == 'windows-latest'
 
       - uses: ./
         id: test_repo
@@ -272,6 +288,11 @@ jobs:
           package-name: ament_copyright
           target-ros2-distro: ${{ matrix.ros_distribution }}
       - run: test -d "${{ steps.test_repo.outputs.ros-workspace-directory-name }}/install/ament_copyright"
+        name: "Check that ament_copyright install directory is present (Non-Windows only)"
+        if: matrix.os != 'windows-latest'
+      - run: test -d "${{ steps.test_repo.outputs.ros-workspace-directory-name }}/install/share/ament_copyright"
+        name: "Check that ament_copyright install directory is present in merged install space (Windows only)"
+        if: matrix.os == 'windows-latest'
 
       - uses: ./
         id: test_colcon_defaults
@@ -287,6 +308,11 @@ jobs:
           target-ros2-distro: ${{ matrix.ros_distribution }}
           vcs-repo-file-url: ${{ env.DISTRO_REPOS_URL }}
       - run: test -d "${{ steps.test_colcon_defaults.outputs.ros-workspace-directory-name }}/install/ament_copyright"
+        name: "Check that ament_copyright install directory is present (Non-Windows only)"
+        if: matrix.os != 'windows-latest'
+      - run: test -d "${{ steps.test_colcon_defaults.outputs.ros-workspace-directory-name }}/install/share/ament_copyright"
+        name: "Check that ament_copyright install directory is present in merged install space (Windows only)"
+        if: matrix.os == 'windows-latest'
       - run: test -d "${{ steps.test_colcon_defaults.outputs.ros-workspace-directory-name }}/build-custom"
 
       # The second repo file is ignored, but will get vcs-import'ed anyway.
@@ -302,6 +328,11 @@ jobs:
           package-name: ament_copyright
           target-ros2-distro: ${{ matrix.ros_distribution }}
       - run: test -d "${{ steps.test_multiple_repos.outputs.ros-workspace-directory-name }}/install/ament_copyright"
+        name: "Check that ament_copyright install directory is present (Non-Windows only)"
+        if: matrix.os != 'windows-latest'
+      - run: test -d "${{ steps.test_multiple_repos.outputs.ros-workspace-directory-name }}/install/share/ament_copyright"
+        name: "Check that ament_copyright install directory is present in merged install space (Windows only)"
+        if: matrix.os == 'windows-latest'
       - run: test -d "${{ steps.test_multiple_repos.outputs.ros-workspace-directory-name }}/src/ament_lint"
       - run: test -d "${{ steps.test_multiple_repos.outputs.ros-workspace-directory-name }}/src/osrf_testing_tools_cpp"
 

--- a/__tests__/ros-ci.test.ts
+++ b/__tests__/ros-ci.test.ts
@@ -1,20 +1,20 @@
 import * as core from "@actions/core";
 import * as actionRosCi from "../src/action-ros-ci";
 import * as dep from "../src/dependencies";
-import { execBashCommand } from "../src/action-ros-ci";
+import { execShellCommand } from "../src/action-ros-ci";
 
 jest.setTimeout(20000); // in milliseconds
 
-describe("execBashCommand test suite", () => {
+describe("execShellCommand test suite", () => {
 	it("calls coreGroup", async () => {
 		const mockGroup = jest.spyOn(core, "group");
-		const result = await execBashCommand('echo "Hello World"');
+		const result = await execShellCommand(["echo Hello World"]);
 		expect(mockGroup).toBeCalled();
 		expect(result).toEqual(0);
 	});
 	it("uses a prefix", async () => {
 		const mockGroup = jest.spyOn(core, "group");
-		const result = await execBashCommand("Hello World", "echo ");
+		const result = await execShellCommand(["echo", "Hello World"]);
 		expect(mockGroup).toBeCalled();
 		expect(result).toEqual(0);
 	});
@@ -23,7 +23,7 @@ describe("execBashCommand test suite", () => {
 		const options = {
 			ignoreReturnCode: true,
 		};
-		const result = execBashCommand("somebadcommand", "", options);
+		const result = execShellCommand(["somebadcommand"], options);
 		expect(mockGroup).toBeCalled();
 		expect(result).not.toEqual(0);
 	});

--- a/dist/index.js
+++ b/dist/index.js
@@ -11144,7 +11144,10 @@ function runTests(colconCommandPrefix, options, testPackageSelection, extra_opti
         if (isWindows) {
             colconTestCmd = [...colconTestCmd, `--merge-install`];
         }
-        yield execShellCommand([...colconCommandPrefix, ...colconTestCmd], options, false);
+        // Temporarily disable colcon test on Windows to unblock Windows CI builds: https://github.com/ros-tooling/action-ros-ci/pull/712#issuecomment-969495087
+        if (!isWindows) {
+            yield execShellCommand([...colconCommandPrefix, ...colconTestCmd], options, false);
+        }
         if (!isWindows) {
             // colcon lcov-result not supported in Windows right now
             // ignoreReturnCode, check comment above in --initial

--- a/dist/index.js
+++ b/dist/index.js
@@ -10947,7 +10947,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.validateDistros = exports.execBashCommand = exports.filterNonEmptyJoin = void 0;
+exports.validateDistros = exports.execShellCommand = exports.filterNonEmptyJoin = void 0;
 const core = __importStar(__nccwpck_require__(2186));
 const github = __importStar(__nccwpck_require__(5438));
 const tr = __importStar(__nccwpck_require__(8159));
@@ -11014,23 +11014,23 @@ function resolveVcsRepoFileUrl(vcsRepoFileUrl) {
     }
 }
 /**
- * Execute a command in bash and wrap the output in a log group.
+ * Execute a shell command and wrap the output in a log group.
  *
- * @param   commandLine     command to execute (can include additional args). Must be correctly escaped.
- * @param   commandPrefix    optional string used to prefix the command to be executed.
+ * @param   command         command to execute w/ any params
+ * @param   use_bash        optionally use bash shell, instead of os default. defaults to true.
  * @param   options         optional exec options.  See ExecOptions
  * @param   log_message     log group title.
  * @returns Promise<number> exit code
  */
-function execBashCommand(commandLine, commandPrefix, options, log_message) {
+function execShellCommand(command, options, use_bash = true, log_message) {
     return __awaiter(this, void 0, void 0, function* () {
-        commandPrefix = commandPrefix || "";
-        const bashScript = `${commandPrefix}${commandLine}`;
-        const message = log_message || `Invoking: bash -c '${bashScript}'`;
         let toolRunnerCommandLine = "";
         let toolRunnerCommandLineArgs = [];
         if (isWindows) {
             toolRunnerCommandLine = "C:\\Windows\\system32\\cmd.exe";
+            const bash_options = use_bash
+                ? [`C:\\Program Files\\Git\\bin\\bash.exe`, `-c`]
+                : [];
             // This passes the same flags to cmd.exe that "run:" in a workflow.
             // https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#using-a-specific-shell
             // Except for /D, which disables the AutoRun functionality from command prompt
@@ -11042,18 +11042,18 @@ function execBashCommand(commandLine, commandPrefix, options, log_message) {
                 "/S",
                 "/C",
                 "call",
-                "%programfiles(x86)%\\Microsoft Visual Studio\\2019\\Enterprise\\VC\\Auxiliary\\Build\\vcvarsall.bat",
-                "amd64",
-                "&",
-                "C:\\Program Files\\Git\\bin\\bash.exe",
-                "-c",
-                bashScript,
+                "%programfiles(x86)%\\Microsoft Visual Studio\\2019\\Enterprise\\VC\\Auxiliary\\Build\\vcvars64.bat",
+                "&&",
+                ...bash_options,
+                ...command,
             ];
         }
         else {
             toolRunnerCommandLine = "bash";
-            toolRunnerCommandLineArgs = ["-c", bashScript];
+            toolRunnerCommandLineArgs = ["-c", ...command];
         }
+        const message = log_message ||
+            `Invoking: ${toolRunnerCommandLine} ${toolRunnerCommandLineArgs}`;
         const runner = new tr.ToolRunner(toolRunnerCommandLine, toolRunnerCommandLineArgs, options);
         if (options && options.silent) {
             return runner.exec();
@@ -11063,7 +11063,7 @@ function execBashCommand(commandLine, commandPrefix, options, log_message) {
         });
     });
 }
-exports.execBashCommand = execBashCommand;
+exports.execShellCommand = execShellCommand;
 //Determine whether all inputs name supported ROS distributions.
 function validateDistros(ros1Distro, ros2Distro) {
     if (!ros1Distro && !ros2Distro) {
@@ -11103,10 +11103,10 @@ function installRosdeps(packageSelection, workspaceDir, options, ros1Distro, ros
         fs_1.default.writeFileSync(scriptPath, scriptContent, { mode: 0o766 });
         let exitCode = 0;
         if (ros1Distro) {
-            exitCode += yield execBashCommand(`./${scriptName} ${ros1Distro}`, "", options);
+            exitCode += yield execShellCommand([`./${scriptName} ${ros1Distro}`], options);
         }
         if (ros2Distro) {
-            exitCode += yield execBashCommand(`./${scriptName} ${ros2Distro}`, "", options);
+            exitCode += yield execShellCommand([`./${scriptName} ${ros2Distro}`], options);
         }
         return exitCode;
     });
@@ -11122,33 +11122,58 @@ function installRosdeps(packageSelection, workspaceDir, options, ros1Distro, ros
  */
 function runTests(colconCommandPrefix, options, testPackageSelection, extra_options, coverageIgnorePattern) {
     return __awaiter(this, void 0, void 0, function* () {
-        // ignoreReturnCode is set to true to avoid having a lack of coverage
-        // data fail the build.
-        const colconLcovInitialCmd = "colcon lcov-result --initial";
-        yield execBashCommand(colconLcovInitialCmd, colconCommandPrefix, Object.assign(Object.assign({}, options), { ignoreReturnCode: true }));
-        const colconTestCmd = filterNonEmptyJoin([
-            `colcon test`,
-            `--event-handlers console_cohesion+`,
-            `--return-code-on-test-failure`,
+        if (!isWindows) {
+            // lcov-result not supported in Windows
+            // ignoreReturnCode is set to true to avoid having a lack of coverage
+            // data fail the build.
+            const colconLcovInitialCmd = [`colcon`, `lcov-result`, `--initial`];
+            yield execShellCommand([...colconCommandPrefix, ...colconLcovInitialCmd], Object.assign(Object.assign({}, options), { ignoreReturnCode: true }), false);
+        }
+        const colconTestCmdOptionsStr = filterNonEmptyJoin([
             testPackageSelection,
             `${extra_options.join(" ")}`,
         ]);
-        yield execBashCommand(colconTestCmd, colconCommandPrefix, options);
-        // ignoreReturnCode, check comment above in --initial
-        const colconLcovResultCmd = filterNonEmptyJoin([
-            `colcon lcov-result`,
-            coverageIgnorePattern !== "" ? `--filter ${coverageIgnorePattern}` : "",
+        const colconTestCmdOptions = colconTestCmdOptionsStr !== "" ? [colconTestCmdOptionsStr] : [];
+        let colconTestCmd = [
+            `colcon`,
+            `test`,
+            `--event-handlers=console_cohesion+`,
+            `--return-code-on-test-failure`,
+            ...colconTestCmdOptions,
+        ];
+        if (isWindows) {
+            colconTestCmd = [...colconTestCmd, `--merge-install`];
+        }
+        yield execShellCommand([...colconCommandPrefix, ...colconTestCmd], options, false);
+        if (!isWindows) {
+            // colcon lcov-result not supported in Windows right now
+            // ignoreReturnCode, check comment above in --initial
+            const colconLcovCmdOptionsStr = filterNonEmptyJoin([
+                coverageIgnorePattern !== "" ? `--filter ${coverageIgnorePattern}` : "",
+                testPackageSelection,
+            ]);
+            const colconLcovCmdOptions = colconLcovCmdOptionsStr !== "" ? [colconLcovCmdOptionsStr] : [];
+            const colconLcovResultCmd = [
+                `colcon`,
+                `lcov-result`,
+                ...colconLcovCmdOptions,
+                `--verbose`,
+            ];
+            yield execShellCommand([...colconCommandPrefix, ...colconLcovResultCmd], Object.assign(Object.assign({}, options), { ignoreReturnCode: true }), false);
+        }
+        const colconCoveragepyCmdOptionsStr = filterNonEmptyJoin([
             testPackageSelection,
-            `--verbose`,
         ]);
-        yield execBashCommand(colconLcovResultCmd, colconCommandPrefix, Object.assign(Object.assign({}, options), { ignoreReturnCode: true }));
-        const colconCoveragepyResultCmd = filterNonEmptyJoin([
-            `colcon coveragepy-result`,
-            testPackageSelection,
+        const colconCoveragepyCmdOptions = colconCoveragepyCmdOptionsStr !== "" ? [colconCoveragepyCmdOptionsStr] : [];
+        const colconCoveragepyResultCmd = [
+            `colcon`,
+            `coveragepy-result`,
+            ...colconCoveragepyCmdOptions,
             `--verbose`,
-            `--coverage-report-args -m`,
-        ]);
-        yield execBashCommand(colconCoveragepyResultCmd, colconCommandPrefix, options);
+            `--coverage-report-args`,
+            `-m`,
+        ];
+        yield execShellCommand([...colconCommandPrefix, ...colconCoveragepyResultCmd], options, false);
     });
 }
 function run_throw() {
@@ -11207,7 +11232,7 @@ function run_throw() {
         // ros-infrastructure/rosdep#610 for instance. So, we do not run it.
         if (!isWindows) {
             yield async_retry_1.default(() => __awaiter(this, void 0, void 0, function* () {
-                yield execBashCommand("rosdep update --include-eol-distros");
+                yield execShellCommand(["rosdep update --include-eol-distros"]);
             }), {
                 retries: 3,
             });
@@ -11244,21 +11269,27 @@ function run_throw() {
             // Unset all local extraheader config entries possibly set by actions/checkout,
             // because local settings take precedence and the default token used by
             // actions/checkout might not have the right permissions for any/all repos
-            yield execBashCommand(`/usr/bin/git config --local --unset-all http.https://github.com/.extraheader || true`, undefined, options);
-            yield execBashCommand(String.raw `/usr/bin/git submodule foreach --recursive git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader'` +
-                ` && git config --local --unset-all 'http.https://github.com/.extraheader' || true`, undefined, options);
+            yield execShellCommand([
+                `/usr/bin/git config --local --unset-all http.https://github.com/.extraheader || true`,
+            ], options);
+            yield execShellCommand([
+                String.raw `/usr/bin/git submodule foreach --recursive git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader'` +
+                    ` && git config --local --unset-all 'http.https://github.com/.extraheader' || true`,
+            ], options);
             // Use a global insteadof entry because local configs aren't observed by git clone
-            yield execBashCommand(`/usr/bin/git config --global url.https://x-access-token:${importToken}@github.com.insteadof 'https://github.com'`, undefined, options);
+            yield execShellCommand([
+                `/usr/bin/git config --global url.https://x-access-token:${importToken}@github.com.insteadof 'https://github.com'`,
+            ], options);
             if (core.isDebug()) {
-                yield execBashCommand(`/usr/bin/git config --list --show-origin || true`, undefined, options);
+                yield execShellCommand([`/usr/bin/git config --list --show-origin || true`], options);
             }
         }
         // Make sure to delete root .colcon directory if it exists
         // This is because, for some reason, using Docker, commands might get run as root
-        yield execBashCommand(`rm -rf ${path.join(path.sep, "root", ".colcon")} || true`, undefined, Object.assign(Object.assign({}, options), { silent: true }));
+        yield execShellCommand([`rm -rf ${path.join(path.sep, "root", ".colcon")} || true`], Object.assign(Object.assign({}, options), { silent: true }));
         for (const vcsRepoFileUrl of vcsRepoFileUrlListNonEmpty) {
             const resolvedUrl = resolveVcsRepoFileUrl(vcsRepoFileUrl);
-            yield execBashCommand(`vcs import --force --recursive src/ --input ${resolvedUrl}`, undefined, options);
+            yield execShellCommand([`vcs import --force --recursive src/ --input ${resolvedUrl}`], options);
         }
         // If the package under tests is part of ros.repos, remove it first.
         // We do not want to allow the "default" head state of the package to
@@ -11280,9 +11311,11 @@ done`;
         const posixRosWorkspaceDir = isWindows
             ? rosWorkspaceDir.replace(/\\/g, "/")
             : rosWorkspaceDir;
-        yield execBashCommand(`vcs diff -s --repos ${posixRosWorkspaceDir} | cut -d ' ' -f 1 | grep "${repo["repo"]}$"` +
-            (isWindows ? ` | ${posixPathScriptPath}` : "") +
-            ` | xargs rm -rf`);
+        yield execShellCommand([
+            `vcs diff -s --repos ${posixRosWorkspaceDir} | cut -d ' ' -f 1 | grep "${repo["repo"]}$"` +
+                (isWindows ? ` | ${posixPathScriptPath}` : "") +
+                ` | xargs rm -rf`,
+        ], undefined);
         // The repo file for the repository needs to be generated on-the-fly to
         // incorporate the custom repository URL and branch name, when a PR is
         // being built.
@@ -11301,17 +11334,17 @@ done`;
     url: 'https://github.com/${repoFullName}.git'
     version: '${commitRef}'`;
         fs_1.default.writeFileSync(repoFilePath, repoFileContent);
-        yield execBashCommand("vcs import --force --recursive src/ < package.repo", undefined, options);
+        yield execShellCommand(["vcs import --force --recursive src/ < package.repo"], options);
         // Print HEAD commits of all repos
-        yield execBashCommand("vcs log -l1 src/", undefined, options);
+        yield execShellCommand(["vcs log -l1 src/"], options);
         if (isLinux) {
             // Always update APT before installing packages on Ubuntu
-            yield execBashCommand("sudo apt-get update");
+            yield execShellCommand(["sudo apt-get update"]);
         }
         yield installRosdeps(buildPackageSelection, rosWorkspaceDir, options, targetRos1Distro, targetRos2Distro);
         if (colconDefaults.includes(`"mixin"`) && colconMixinRepo !== "") {
-            yield execBashCommand(`colcon mixin add default '${colconMixinRepo}'`, undefined, options);
-            yield execBashCommand("colcon mixin update default", undefined, options);
+            yield execShellCommand([`colcon`, `mixin`, `add`, `default`, `'${colconMixinRepo}'`], options, false);
+            yield execShellCommand([`colcon`, `mixin`, `update`, `default`], options, false);
         }
         let extra_options = [];
         if (colconExtraArgs !== "") {
@@ -11332,18 +11365,26 @@ done`;
         // where this does not happen. See issue #26 for relevant CI logs.
         core.addPath(path.join(rosWorkspaceDir, "install", "bin"));
         // Source any installed ROS distributions if they are present
-        let colconCommandPrefix = "";
+        let colconCommandPrefix = [];
         if (isLinux) {
             if (targetRos1Distro) {
                 const ros1SetupPath = `/opt/ros/${targetRos1Distro}/setup.sh`;
                 if (fs_1.default.existsSync(ros1SetupPath)) {
-                    colconCommandPrefix += `source ${ros1SetupPath} && `;
+                    colconCommandPrefix = [
+                        ...colconCommandPrefix,
+                        `source ${ros1SetupPath}`,
+                        `&&`,
+                    ];
                 }
             }
             if (targetRos2Distro) {
                 const ros2SetupPath = `/opt/ros/${targetRos2Distro}/setup.sh`;
                 if (fs_1.default.existsSync(ros2SetupPath)) {
-                    colconCommandPrefix += `source ${ros2SetupPath} && `;
+                    colconCommandPrefix = [
+                        ...colconCommandPrefix,
+                        `source ${ros2SetupPath}`,
+                        `&&`,
+                    ];
                 }
             }
         }
@@ -11352,21 +11393,31 @@ done`;
             if (targetRos2Distro) {
                 const ros2SetupPath = `c:/dev/${targetRos2Distro}/ros2-windows/setup.bat`;
                 if (fs_1.default.existsSync(ros2SetupPath)) {
-                    colconCommandPrefix += `${ros2SetupPath} && `;
+                    colconCommandPrefix = [
+                        ...colconCommandPrefix,
+                        `${ros2SetupPath}`,
+                        `&&`,
+                    ];
                 }
             }
         }
-        let colconBuildCmd = filterNonEmptyJoin([
-            `colcon build`,
-            `--event-handlers console_cohesion+`,
+        const colconBuildCmdOptionsStr = filterNonEmptyJoin([
             buildPackageSelection,
             `${extra_options.join(" ")}`,
             extraCmakeArgs !== "" ? `--cmake-args ${extraCmakeArgs}` : "",
         ]);
-        if (!isWindows) {
-            colconBuildCmd = colconBuildCmd.concat(" --symlink-install");
+        const colconBuildCmdOptions = colconBuildCmdOptionsStr !== "" ? [colconBuildCmdOptionsStr] : [];
+        let colconBuildCmd = [
+            `colcon`,
+            `build`,
+            `--symlink-install`,
+            ...colconBuildCmdOptions,
+            `--event-handlers=console_cohesion+`,
+        ];
+        if (isWindows) {
+            colconBuildCmd = [...colconBuildCmd, `--merge-install`];
         }
-        yield execBashCommand(colconBuildCmd, colconCommandPrefix, options);
+        yield execShellCommand([...colconCommandPrefix, ...colconBuildCmd], options, false);
         if (!skipTests) {
             yield runTests(colconCommandPrefix, options, testPackageSelection, extra_options, coverageIgnorePattern);
         }
@@ -11375,7 +11426,9 @@ done`;
         }
         if (importToken !== "") {
             // Unset config so that it doesn't leak to other actions
-            yield execBashCommand(`/usr/bin/git config --global --unset-all url.https://x-access-token:${importToken}@github.com.insteadof`, undefined, options);
+            yield execShellCommand([
+                `/usr/bin/git config --global --unset-all url.https://x-access-token:${importToken}@github.com.insteadof`,
+            ], options);
         }
     });
 }

--- a/dist/index.js
+++ b/dist/index.js
@@ -11026,7 +11026,7 @@ function execShellCommand(command, options, force_bash = true, log_message) {
     return __awaiter(this, void 0, void 0, function* () {
         const use_bash = !isWindows || force_bash;
         if (use_bash) {
-            // Bash command needs to be flattened into a single string when passed to bash with "-c" switch
+            // Bash commands needs to be flattened into a single string when passed to bash with "-c" switch
             command = [filterNonEmptyJoin(command)];
             if (isWindows) {
                 command = [
@@ -11102,7 +11102,7 @@ function installRosdeps(packageSelection, workspaceDir, options, ros1Distro, ros
 		exit 1
 	fi
 	DISTRO=$1
-	package_paths=$(colcon list --paths-only ${packageSelection})
+	package_paths=$(colcon list --paths-only ${filterNonEmptyJoin(packageSelection)})
 	# suppress errors from unresolved install keys to preserve backwards compatibility
 	# due to difficulty reading names of some non-catkin dependencies in the ros2 core
 	# see https://index.ros.org/doc/ros2/Installation/Foxy/Linux-Development-Setup/#install-dependencies-using-rosdep
@@ -11123,11 +11123,11 @@ function installRosdeps(packageSelection, workspaceDir, options, ros1Distro, ros
  *
  * @param colconCommandPrefix the prefix to use before colcon commands
  * @param options the exec options
- * @param testPackageSelection the package selection option string
- * @param extra_options the extra options for 'colcon test'
- * @param coverageIgnorePattern the coverage filter pattern to use for lcov, or an empty string
+ * @param testPackageSelection the package selection option
+ * @param colconExtraArgs the extra args for 'colcon test'
+ * @param coverageIgnorePattern the coverage filter pattern to use for lcov
  */
-function runTests(colconCommandPrefix, options, testPackageSelection, extra_options, coverageIgnorePattern) {
+function runTests(colconCommandPrefix, options, testPackageSelection, colconExtraArgs, coverageIgnorePattern) {
     return __awaiter(this, void 0, void 0, function* () {
         if (!isWindows) {
             // lcov-result not supported in Windows
@@ -11136,17 +11136,13 @@ function runTests(colconCommandPrefix, options, testPackageSelection, extra_opti
             const colconLcovInitialCmd = [`colcon`, `lcov-result`, `--initial`];
             yield execShellCommand([...colconCommandPrefix, ...colconLcovInitialCmd], Object.assign(Object.assign({}, options), { ignoreReturnCode: true }), false);
         }
-        const colconTestCmdOptionsStr = filterNonEmptyJoin([
-            testPackageSelection,
-            `${extra_options.join(" ")}`,
-        ]);
-        const colconTestCmdOptions = colconTestCmdOptionsStr !== "" ? [colconTestCmdOptionsStr] : [];
         let colconTestCmd = [
             `colcon`,
             `test`,
             `--event-handlers=console_cohesion+`,
             `--return-code-on-test-failure`,
-            ...colconTestCmdOptions,
+            ...testPackageSelection,
+            ...colconExtraArgs,
         ];
         if (isWindows) {
             colconTestCmd = [...colconTestCmd, `--merge-install`];
@@ -11158,27 +11154,19 @@ function runTests(colconCommandPrefix, options, testPackageSelection, extra_opti
         if (!isWindows) {
             // colcon lcov-result not supported in Windows right now
             // ignoreReturnCode, check comment above in --initial
-            const colconLcovCmdOptionsStr = filterNonEmptyJoin([
-                coverageIgnorePattern !== "" ? `--filter ${coverageIgnorePattern}` : "",
-                testPackageSelection,
-            ]);
-            const colconLcovCmdOptions = colconLcovCmdOptionsStr !== "" ? [colconLcovCmdOptionsStr] : [];
             const colconLcovResultCmd = [
                 `colcon`,
                 `lcov-result`,
-                ...colconLcovCmdOptions,
+                ...testPackageSelection,
+                ...coverageIgnorePattern,
                 `--verbose`,
             ];
             yield execShellCommand([...colconCommandPrefix, ...colconLcovResultCmd], Object.assign(Object.assign({}, options), { ignoreReturnCode: true }), false);
         }
-        const colconCoveragepyCmdOptionsStr = filterNonEmptyJoin([
-            testPackageSelection,
-        ]);
-        const colconCoveragepyCmdOptions = colconCoveragepyCmdOptionsStr !== "" ? [colconCoveragepyCmdOptionsStr] : [];
         const colconCoveragepyResultCmd = [
             `colcon`,
             `coveragepy-result`,
-            ...colconCoveragepyCmdOptions,
+            ...testPackageSelection,
             `--verbose`,
             `--coverage-report-args`,
             `-m`,
@@ -11192,19 +11180,27 @@ function run_throw() {
         const workspace = process.env.GITHUB_WORKSPACE;
         const colconDefaults = core.getInput("colcon-defaults");
         const colconMixinRepo = core.getInput("colcon-mixin-repository");
-        const extraCmakeArgs = core.getInput("extra-cmake-args");
-        const colconExtraArgs = core.getInput("colcon-extra-args");
+        const extraCmakeArgsInput = core.getInput("extra-cmake-args");
+        const extraCmakeArgs = extraCmakeArgsInput
+            ? ["--cmake-args", extraCmakeArgsInput]
+            : [];
+        const coverageIgnorePatternInput = core.getInput("coverage-ignore-pattern");
+        const coverageIgnorePattern = coverageIgnorePatternInput
+            ? ["--filter", coverageIgnorePatternInput]
+            : [];
+        const colconExtraArgsInput = core.getInput("colcon-extra-args");
+        const colconExtraArgs = colconExtraArgsInput ? [colconExtraArgsInput] : [];
         const importToken = core.getInput("import-token");
         const packageNameInput = core.getInput("package-name");
         const packageNames = packageNameInput
-            ? filterNonEmptyJoin(packageNameInput.split(RegExp("\\s")))
+            ? packageNameInput.split(RegExp("\\s"))
             : undefined;
         const buildPackageSelection = packageNames
-            ? `--packages-up-to ${packageNames}`
-            : "";
+            ? ["--packages-up-to", ...packageNames]
+            : [];
         const testPackageSelection = packageNames
-            ? `--packages-select ${packageNames}`
-            : "";
+            ? ["--packages-select", ...packageNames]
+            : [];
         const rosWorkspaceName = "ros_ws";
         core.setOutput("ros-workspace-directory-name", rosWorkspaceName);
         const rosWorkspaceDir = path.join(workspace, rosWorkspaceName);
@@ -11234,7 +11230,6 @@ function run_throw() {
         });
         vcsRepoFileUrlList = vcsRepoFileUrlList.concat(vcsReposSupplemental);
         const vcsRepoFileUrlListNonEmpty = vcsRepoFileUrlList.filter((x) => x != "");
-        const coverageIgnorePattern = core.getInput("coverage-ignore-pattern");
         if (!validateDistros(targetRos1Distro, targetRos2Distro)) {
             return;
         }
@@ -11356,10 +11351,6 @@ done`;
             yield execShellCommand([`colcon`, `mixin`, `add`, `default`, `'${colconMixinRepo}'`], options, false);
             yield execShellCommand([`colcon`, `mixin`, `update`, `default`], options, false);
         }
-        let extra_options = [];
-        if (colconExtraArgs !== "") {
-            extra_options = extra_options.concat(colconExtraArgs);
-        }
         // Add the future install bin directory to PATH.
         // This enables cmake find_package to find packages installed in the
         // colcon install directory, even if local_setup.sh has not been sourced.
@@ -11411,17 +11402,13 @@ done`;
                 }
             }
         }
-        const colconBuildCmdOptionsStr = filterNonEmptyJoin([
-            buildPackageSelection,
-            `${extra_options.join(" ")}`,
-            extraCmakeArgs !== "" ? `--cmake-args ${extraCmakeArgs}` : "",
-        ]);
-        const colconBuildCmdOptions = colconBuildCmdOptionsStr !== "" ? [colconBuildCmdOptionsStr] : [];
         let colconBuildCmd = [
             `colcon`,
             `build`,
             `--symlink-install`,
-            ...colconBuildCmdOptions,
+            ...buildPackageSelection,
+            ...colconExtraArgs,
+            ...extraCmakeArgs,
             `--event-handlers=console_cohesion+`,
         ];
         if (isWindows) {
@@ -11429,7 +11416,7 @@ done`;
         }
         yield execShellCommand([...colconCommandPrefix, ...colconBuildCmd], options, false);
         if (!skipTests) {
-            yield runTests(colconCommandPrefix, options, testPackageSelection, extra_options, coverageIgnorePattern);
+            yield runTests(colconCommandPrefix, options, testPackageSelection, colconExtraArgs, coverageIgnorePattern);
         }
         else {
             core.info("Skipping tests");

--- a/dist/index.js
+++ b/dist/index.js
@@ -11025,7 +11025,9 @@ function resolveVcsRepoFileUrl(vcsRepoFileUrl) {
 function execShellCommand(command, options, use_bash = true, log_message) {
     return __awaiter(this, void 0, void 0, function* () {
         if (use_bash) {
+            console.log("melvin1: " + command);
             command = [filterNonEmptyJoin(command)];
+            console.log("melvin2: " + command);
         }
         let toolRunnerCommandLine = "";
         let toolRunnerCommandLineArgs = [];

--- a/dist/index.js
+++ b/dist/index.js
@@ -11348,7 +11348,7 @@ done`;
         }
         yield installRosdeps(buildPackageSelection, rosWorkspaceDir, options, targetRos1Distro, targetRos2Distro);
         if (colconDefaults.includes(`"mixin"`) && colconMixinRepo !== "") {
-            yield execShellCommand([`colcon`, `mixin`, `add`, `default`, `'${colconMixinRepo}'`], options, false);
+            yield execShellCommand([`colcon`, `mixin`, `add`, `default`, `${colconMixinRepo}`], options, false);
             yield execShellCommand([`colcon`, `mixin`, `update`, `default`], options, false);
         }
         // Add the future install bin directory to PATH.

--- a/dist/index.js
+++ b/dist/index.js
@@ -11024,11 +11024,14 @@ function resolveVcsRepoFileUrl(vcsRepoFileUrl) {
  */
 function execShellCommand(command, options, use_bash = true, log_message) {
     return __awaiter(this, void 0, void 0, function* () {
+        if (use_bash) {
+            command = [filterNonEmptyJoin(command)];
+        }
         let toolRunnerCommandLine = "";
         let toolRunnerCommandLineArgs = [];
         if (isWindows) {
             toolRunnerCommandLine = "C:\\Windows\\system32\\cmd.exe";
-            const bash_options = use_bash
+            const bash_prefix = use_bash
                 ? [`C:\\Program Files\\Git\\bin\\bash.exe`, `-c`]
                 : [];
             // This passes the same flags to cmd.exe that "run:" in a workflow.
@@ -11044,7 +11047,7 @@ function execShellCommand(command, options, use_bash = true, log_message) {
                 "call",
                 "%programfiles(x86)%\\Microsoft Visual Studio\\2019\\Enterprise\\VC\\Auxiliary\\Build\\vcvars64.bat",
                 "&&",
-                ...bash_options,
+                ...bash_prefix,
                 ...command,
             ];
         }

--- a/src/action-ros-ci.ts
+++ b/src/action-ros-ci.ts
@@ -82,7 +82,9 @@ export async function execShellCommand(
 	log_message?: string
 ): Promise<number> {
 	if (use_bash) {
+		console.log("melvin1: " + command);
 		command = [filterNonEmptyJoin(command)];
+		console.log("melvin2: " + command);
 	}
 
 	let toolRunnerCommandLine = "";

--- a/src/action-ros-ci.ts
+++ b/src/action-ros-ci.ts
@@ -81,11 +81,15 @@ export async function execShellCommand(
 	use_bash: boolean = true,
 	log_message?: string
 ): Promise<number> {
+	if (use_bash) {
+		command = [filterNonEmptyJoin(command)];
+	}
+
 	let toolRunnerCommandLine = "";
 	let toolRunnerCommandLineArgs: string[] = [];
 	if (isWindows) {
 		toolRunnerCommandLine = "C:\\Windows\\system32\\cmd.exe";
-		const bash_options: string[] = use_bash
+		const bash_prefix: string[] = use_bash
 			? [`C:\\Program Files\\Git\\bin\\bash.exe`, `-c`]
 			: [];
 		// This passes the same flags to cmd.exe that "run:" in a workflow.
@@ -101,7 +105,7 @@ export async function execShellCommand(
 			"call",
 			"%programfiles(x86)%\\Microsoft Visual Studio\\2019\\Enterprise\\VC\\Auxiliary\\Build\\vcvars64.bat",
 			"&&",
-			...bash_options,
+			...bash_prefix,
 			...command,
 		];
 	} else {

--- a/src/action-ros-ci.ts
+++ b/src/action-ros-ci.ts
@@ -67,28 +67,27 @@ function resolveVcsRepoFileUrl(vcsRepoFileUrl: string): string {
 }
 
 /**
- * Execute a command in bash and wrap the output in a log group.
+ * Execute a shell command and wrap the output in a log group.
  *
- * @param   commandLine     command to execute (can include additional args). Must be correctly escaped.
- * @param   commandPrefix    optional string used to prefix the command to be executed.
+ * @param   command         command to execute w/ any params
+ * @param   use_bash        optionally use bash shell, instead of os default. defaults to true.
  * @param   options         optional exec options.  See ExecOptions
  * @param   log_message     log group title.
  * @returns Promise<number> exit code
  */
-export async function execBashCommand(
-	commandLine: string,
-	commandPrefix?: string,
+export async function execShellCommand(
+	command: string[],
 	options?: im.ExecOptions,
+	use_bash: boolean = true,
 	log_message?: string
 ): Promise<number> {
-	commandPrefix = commandPrefix || "";
-	const bashScript = `${commandPrefix}${commandLine}`;
-	const message = log_message || `Invoking: bash -c '${bashScript}'`;
-
 	let toolRunnerCommandLine = "";
 	let toolRunnerCommandLineArgs: string[] = [];
 	if (isWindows) {
 		toolRunnerCommandLine = "C:\\Windows\\system32\\cmd.exe";
+		const bash_options: string[] = use_bash
+			? [`C:\\Program Files\\Git\\bin\\bash.exe`, `-c`]
+			: [];
 		// This passes the same flags to cmd.exe that "run:" in a workflow.
 		// https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#using-a-specific-shell
 		// Except for /D, which disables the AutoRun functionality from command prompt
@@ -100,17 +99,18 @@ export async function execBashCommand(
 			"/S",
 			"/C",
 			"call",
-			"%programfiles(x86)%\\Microsoft Visual Studio\\2019\\Enterprise\\VC\\Auxiliary\\Build\\vcvarsall.bat",
-			"amd64",
-			"&",
-			"C:\\Program Files\\Git\\bin\\bash.exe",
-			"-c",
-			bashScript,
+			"%programfiles(x86)%\\Microsoft Visual Studio\\2019\\Enterprise\\VC\\Auxiliary\\Build\\vcvars64.bat",
+			"&&",
+			...bash_options,
+			...command,
 		];
 	} else {
 		toolRunnerCommandLine = "bash";
-		toolRunnerCommandLineArgs = ["-c", bashScript];
+		toolRunnerCommandLineArgs = ["-c", ...command];
 	}
+	const message =
+		log_message ||
+		`Invoking: ${toolRunnerCommandLine} ${toolRunnerCommandLineArgs}`;
 	const runner: tr.ToolRunner = new tr.ToolRunner(
 		toolRunnerCommandLine,
 		toolRunnerCommandLineArgs,
@@ -178,16 +178,14 @@ async function installRosdeps(
 
 	let exitCode = 0;
 	if (ros1Distro) {
-		exitCode += await execBashCommand(
-			`./${scriptName} ${ros1Distro}`,
-			"",
+		exitCode += await execShellCommand(
+			[`./${scriptName} ${ros1Distro}`],
 			options
 		);
 	}
 	if (ros2Distro) {
-		exitCode += await execBashCommand(
-			`./${scriptName} ${ros2Distro}`,
-			"",
+		exitCode += await execShellCommand(
+			[`./${scriptName} ${ros2Distro}`],
 			options
 		);
 	}
@@ -204,51 +202,91 @@ async function installRosdeps(
  * @param coverageIgnorePattern the coverage filter pattern to use for lcov, or an empty string
  */
 async function runTests(
-	colconCommandPrefix: string,
+	colconCommandPrefix: string[],
 	options: im.ExecOptions,
 	testPackageSelection: string,
 	extra_options: string[],
 	coverageIgnorePattern: string
 ): Promise<void> {
-	// ignoreReturnCode is set to true to avoid having a lack of coverage
-	// data fail the build.
-	const colconLcovInitialCmd = "colcon lcov-result --initial";
-	await execBashCommand(colconLcovInitialCmd, colconCommandPrefix, {
-		...options,
-		ignoreReturnCode: true,
-	});
+	if (!isWindows) {
+		// lcov-result not supported in Windows
+		// ignoreReturnCode is set to true to avoid having a lack of coverage
+		// data fail the build.
+		const colconLcovInitialCmd = [`colcon`, `lcov-result`, `--initial`];
+		await execShellCommand(
+			[...colconCommandPrefix, ...colconLcovInitialCmd],
+			{
+				...options,
+				ignoreReturnCode: true,
+			},
+			false
+		);
+	}
 
-	const colconTestCmd = filterNonEmptyJoin([
-		`colcon test`,
-		`--event-handlers console_cohesion+`,
-		`--return-code-on-test-failure`,
+	const colconTestCmdOptionsStr = filterNonEmptyJoin([
 		testPackageSelection,
 		`${extra_options.join(" ")}`,
 	]);
-	await execBashCommand(colconTestCmd, colconCommandPrefix, options);
+	const colconTestCmdOptions =
+		colconTestCmdOptionsStr !== "" ? [colconTestCmdOptionsStr] : [];
+	let colconTestCmd = [
+		`colcon`,
+		`test`,
+		`--event-handlers=console_cohesion+`,
+		`--return-code-on-test-failure`,
+		...colconTestCmdOptions,
+	];
+	if (isWindows) {
+		colconTestCmd = [...colconTestCmd, `--merge-install`];
+	}
+	await execShellCommand(
+		[...colconCommandPrefix, ...colconTestCmd],
+		options,
+		false
+	);
 
-	// ignoreReturnCode, check comment above in --initial
-	const colconLcovResultCmd = filterNonEmptyJoin([
-		`colcon lcov-result`,
-		coverageIgnorePattern !== "" ? `--filter ${coverageIgnorePattern}` : "",
-		testPackageSelection,
-		`--verbose`,
-	]);
-	await execBashCommand(colconLcovResultCmd, colconCommandPrefix, {
-		...options,
-		ignoreReturnCode: true,
-	});
+	if (!isWindows) {
+		// colcon lcov-result not supported in Windows right now
+		// ignoreReturnCode, check comment above in --initial
+		const colconLcovCmdOptionsStr = filterNonEmptyJoin([
+			coverageIgnorePattern !== "" ? `--filter ${coverageIgnorePattern}` : "",
+			testPackageSelection,
+		]);
+		const colconLcovCmdOptions =
+			colconLcovCmdOptionsStr !== "" ? [colconLcovCmdOptionsStr] : [];
+		const colconLcovResultCmd = [
+			`colcon`,
+			`lcov-result`,
+			...colconLcovCmdOptions,
+			`--verbose`,
+		];
+		await execShellCommand(
+			[...colconCommandPrefix, ...colconLcovResultCmd],
+			{
+				...options,
+				ignoreReturnCode: true,
+			},
+			false
+		);
+	}
 
-	const colconCoveragepyResultCmd = filterNonEmptyJoin([
-		`colcon coveragepy-result`,
+	const colconCoveragepyCmdOptionsStr = filterNonEmptyJoin([
 		testPackageSelection,
-		`--verbose`,
-		`--coverage-report-args -m`,
 	]);
-	await execBashCommand(
-		colconCoveragepyResultCmd,
-		colconCommandPrefix,
-		options
+	const colconCoveragepyCmdOptions =
+		colconCoveragepyCmdOptionsStr !== "" ? [colconCoveragepyCmdOptionsStr] : [];
+	const colconCoveragepyResultCmd = [
+		`colcon`,
+		`coveragepy-result`,
+		...colconCoveragepyCmdOptions,
+		`--verbose`,
+		`--coverage-report-args`,
+		`-m`,
+	];
+	await execShellCommand(
+		[...colconCommandPrefix, ...colconCoveragepyResultCmd],
+		options,
+		false
 	);
 }
 
@@ -323,7 +361,7 @@ async function run_throw(): Promise<void> {
 	if (!isWindows) {
 		await retry(
 			async () => {
-				await execBashCommand("rosdep update --include-eol-distros");
+				await execShellCommand(["rosdep update --include-eol-distros"]);
 			},
 			{
 				retries: 3,
@@ -383,27 +421,29 @@ async function run_throw(): Promise<void> {
 		// Unset all local extraheader config entries possibly set by actions/checkout,
 		// because local settings take precedence and the default token used by
 		// actions/checkout might not have the right permissions for any/all repos
-		await execBashCommand(
-			`/usr/bin/git config --local --unset-all http.https://github.com/.extraheader || true`,
-			undefined,
+		await execShellCommand(
+			[
+				`/usr/bin/git config --local --unset-all http.https://github.com/.extraheader || true`,
+			],
 			options
 		);
-		await execBashCommand(
-			String.raw`/usr/bin/git submodule foreach --recursive git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader'` +
-				` && git config --local --unset-all 'http.https://github.com/.extraheader' || true`,
-			undefined,
+		await execShellCommand(
+			[
+				String.raw`/usr/bin/git submodule foreach --recursive git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader'` +
+					` && git config --local --unset-all 'http.https://github.com/.extraheader' || true`,
+			],
 			options
 		);
 		// Use a global insteadof entry because local configs aren't observed by git clone
-		await execBashCommand(
-			`/usr/bin/git config --global url.https://x-access-token:${importToken}@github.com.insteadof 'https://github.com'`,
-			undefined,
+		await execShellCommand(
+			[
+				`/usr/bin/git config --global url.https://x-access-token:${importToken}@github.com.insteadof 'https://github.com'`,
+			],
 			options
 		);
 		if (core.isDebug()) {
-			await execBashCommand(
-				`/usr/bin/git config --list --show-origin || true`,
-				undefined,
+			await execShellCommand(
+				[`/usr/bin/git config --list --show-origin || true`],
 				options
 			);
 		}
@@ -411,17 +451,15 @@ async function run_throw(): Promise<void> {
 
 	// Make sure to delete root .colcon directory if it exists
 	// This is because, for some reason, using Docker, commands might get run as root
-	await execBashCommand(
-		`rm -rf ${path.join(path.sep, "root", ".colcon")} || true`,
-		undefined,
+	await execShellCommand(
+		[`rm -rf ${path.join(path.sep, "root", ".colcon")} || true`],
 		{ ...options, silent: true }
 	);
 
 	for (const vcsRepoFileUrl of vcsRepoFileUrlListNonEmpty) {
 		const resolvedUrl = resolveVcsRepoFileUrl(vcsRepoFileUrl);
-		await execBashCommand(
-			`vcs import --force --recursive src/ --input ${resolvedUrl}`,
-			undefined,
+		await execShellCommand(
+			[`vcs import --force --recursive src/ --input ${resolvedUrl}`],
 			options
 		);
 	}
@@ -446,10 +484,13 @@ done`;
 	const posixRosWorkspaceDir = isWindows
 		? rosWorkspaceDir.replace(/\\/g, "/")
 		: rosWorkspaceDir;
-	await execBashCommand(
-		`vcs diff -s --repos ${posixRosWorkspaceDir} | cut -d ' ' -f 1 | grep "${repo["repo"]}$"` +
-			(isWindows ? ` | ${posixPathScriptPath}` : "") +
-			` | xargs rm -rf`
+	await execShellCommand(
+		[
+			`vcs diff -s --repos ${posixRosWorkspaceDir} | cut -d ' ' -f 1 | grep "${repo["repo"]}$"` +
+				(isWindows ? ` | ${posixPathScriptPath}` : "") +
+				` | xargs rm -rf`,
+		],
+		undefined
 	);
 
 	// The repo file for the repository needs to be generated on-the-fly to
@@ -470,18 +511,17 @@ done`;
     url: 'https://github.com/${repoFullName}.git'
     version: '${commitRef}'`;
 	fs.writeFileSync(repoFilePath, repoFileContent);
-	await execBashCommand(
-		"vcs import --force --recursive src/ < package.repo",
-		undefined,
+	await execShellCommand(
+		["vcs import --force --recursive src/ < package.repo"],
 		options
 	);
 
 	// Print HEAD commits of all repos
-	await execBashCommand("vcs log -l1 src/", undefined, options);
+	await execShellCommand(["vcs log -l1 src/"], options);
 
 	if (isLinux) {
 		// Always update APT before installing packages on Ubuntu
-		await execBashCommand("sudo apt-get update");
+		await execShellCommand(["sudo apt-get update"]);
 	}
 	await installRosdeps(
 		buildPackageSelection,
@@ -492,12 +532,16 @@ done`;
 	);
 
 	if (colconDefaults.includes(`"mixin"`) && colconMixinRepo !== "") {
-		await execBashCommand(
-			`colcon mixin add default '${colconMixinRepo}'`,
-			undefined,
-			options
+		await execShellCommand(
+			[`colcon`, `mixin`, `add`, `default`, `'${colconMixinRepo}'`],
+			options,
+			false
 		);
-		await execBashCommand("colcon mixin update default", undefined, options);
+		await execShellCommand(
+			[`colcon`, `mixin`, `update`, `default`],
+			options,
+			false
+		);
 	}
 
 	let extra_options: string[] = [];
@@ -521,18 +565,26 @@ done`;
 	core.addPath(path.join(rosWorkspaceDir, "install", "bin"));
 
 	// Source any installed ROS distributions if they are present
-	let colconCommandPrefix = "";
+	let colconCommandPrefix: string[] = [];
 	if (isLinux) {
 		if (targetRos1Distro) {
 			const ros1SetupPath = `/opt/ros/${targetRos1Distro}/setup.sh`;
 			if (fs.existsSync(ros1SetupPath)) {
-				colconCommandPrefix += `source ${ros1SetupPath} && `;
+				colconCommandPrefix = [
+					...colconCommandPrefix,
+					`source ${ros1SetupPath}`,
+					`&&`,
+				];
 			}
 		}
 		if (targetRos2Distro) {
 			const ros2SetupPath = `/opt/ros/${targetRos2Distro}/setup.sh`;
 			if (fs.existsSync(ros2SetupPath)) {
-				colconCommandPrefix += `source ${ros2SetupPath} && `;
+				colconCommandPrefix = [
+					...colconCommandPrefix,
+					`source ${ros2SetupPath}`,
+					`&&`,
+				];
 			}
 		}
 	} else if (isWindows) {
@@ -540,22 +592,37 @@ done`;
 		if (targetRos2Distro) {
 			const ros2SetupPath = `c:/dev/${targetRos2Distro}/ros2-windows/setup.bat`;
 			if (fs.existsSync(ros2SetupPath)) {
-				colconCommandPrefix += `${ros2SetupPath} && `;
+				colconCommandPrefix = [
+					...colconCommandPrefix,
+					`${ros2SetupPath}`,
+					`&&`,
+				];
 			}
 		}
 	}
 
-	let colconBuildCmd = filterNonEmptyJoin([
-		`colcon build`,
-		`--event-handlers console_cohesion+`,
+	const colconBuildCmdOptionsStr = filterNonEmptyJoin([
 		buildPackageSelection,
 		`${extra_options.join(" ")}`,
 		extraCmakeArgs !== "" ? `--cmake-args ${extraCmakeArgs}` : "",
 	]);
-	if (!isWindows) {
-		colconBuildCmd = colconBuildCmd.concat(" --symlink-install");
+	const colconBuildCmdOptions =
+		colconBuildCmdOptionsStr !== "" ? [colconBuildCmdOptionsStr] : [];
+	let colconBuildCmd = [
+		`colcon`,
+		`build`,
+		`--symlink-install`,
+		...colconBuildCmdOptions,
+		`--event-handlers=console_cohesion+`,
+	];
+	if (isWindows) {
+		colconBuildCmd = [...colconBuildCmd, `--merge-install`];
 	}
-	await execBashCommand(colconBuildCmd, colconCommandPrefix, options);
+	await execShellCommand(
+		[...colconCommandPrefix, ...colconBuildCmd],
+		options,
+		false
+	);
 
 	if (!skipTests) {
 		await runTests(
@@ -571,9 +638,10 @@ done`;
 
 	if (importToken !== "") {
 		// Unset config so that it doesn't leak to other actions
-		await execBashCommand(
-			`/usr/bin/git config --global --unset-all url.https://x-access-token:${importToken}@github.com.insteadof`,
-			undefined,
+		await execShellCommand(
+			[
+				`/usr/bin/git config --global --unset-all url.https://x-access-token:${importToken}@github.com.insteadof`,
+			],
 			options
 		);
 	}

--- a/src/action-ros-ci.ts
+++ b/src/action-ros-ci.ts
@@ -543,7 +543,7 @@ done`;
 
 	if (colconDefaults.includes(`"mixin"`) && colconMixinRepo !== "") {
 		await execShellCommand(
-			[`colcon`, `mixin`, `add`, `default`, `'${colconMixinRepo}'`],
+			[`colcon`, `mixin`, `add`, `default`, `${colconMixinRepo}`],
 			options,
 			false
 		);

--- a/src/action-ros-ci.ts
+++ b/src/action-ros-ci.ts
@@ -239,11 +239,15 @@ async function runTests(
 	if (isWindows) {
 		colconTestCmd = [...colconTestCmd, `--merge-install`];
 	}
-	await execShellCommand(
-		[...colconCommandPrefix, ...colconTestCmd],
-		options,
-		false
-	);
+
+	// Temporarily disable colcon test on Windows to unblock Windows CI builds: https://github.com/ros-tooling/action-ros-ci/pull/712#issuecomment-969495087
+	if (!isWindows) {
+		await execShellCommand(
+			[...colconCommandPrefix, ...colconTestCmd],
+			options,
+			false
+		);
+	}
 
 	if (!isWindows) {
 		// colcon lcov-result not supported in Windows right now


### PR DESCRIPTION
* run in cmd instead of bash
* disable colcon-lcov result
* use --merge-install as suggessted in ros2 docs
* disable colcon-test on windows

Windows Test and Test-Coverage functionality will be addressed in a future pr

Signed-off-by: Melvin Wang <melvin.mc.wang@gmail.com>