### PR TITLE
Update tests and README after official Humble release

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -98,8 +98,6 @@ jobs:
       - uses: ros-tooling/setup-ros@master
         with:
           required-ros-distributions: ${{ matrix.ros_distribution }}
-          # TODO remove this once Humble has been officially released
-          use-ros2-testing: ${{ matrix.ros_distribution == 'humble' }}
       - uses: ./
         id: test_all_packages_in_repo
         name: "Test all packages in single repo, default options"
@@ -172,9 +170,8 @@ jobs:
             ros_distribution: galactic
 
           # Humble Hawksbill (May 2022 - May 2027)
-          # TODO uncomment once humble is supported by setup-ros-docker
-          # - docker_image: rostooling/setup-ros-docker:ubuntu-jammy-ros-humble-ros-base-latest
-          #   ros_distribution: humble
+          - docker_image: rostooling/setup-ros-docker:ubuntu-jammy-ros-humble-ros-base-latest
+            ros_distribution: humble
 
           # Rolling Ridley (see REP 2002: https://www.ros.org/reps/rep-2002.html)
           - docker_image: rostooling/setup-ros-docker:ubuntu-jammy-ros-rolling-ros-base-latest

--- a/README.md
+++ b/README.md
@@ -82,11 +82,11 @@ In this case, `action-ros-ci` will rely on `setup-ros` for installing ROS 2 bina
 steps:
   - uses: ros-tooling/setup-ros@v0.3
     with:
-      required-ros-distributions: galactic
+      required-ros-distributions: humble
   - uses: ros-tooling/action-ros-ci@v0.2
     with:
       package-name: my_package
-      target-ros2-distro: galactic
+      target-ros2-distro: humble
 ```
 
 #### Building ROS 2 dependencies from source
@@ -99,8 +99,8 @@ steps:
   - uses: ros-tooling/action-ros-ci@v0.2
     with:
       package-name: my_package
-      target-ros2-distro: galactic
-      vcs-repo-file-url: https://raw.githubusercontent.com/ros2/ros2/galactic/ros2.repos
+      target-ros2-distro: humble
+      vcs-repo-file-url: https://raw.githubusercontent.com/ros2/ros2/humble/ros2.repos
 ```
 
 ### Build with a custom `repos` or `rosinstall` file
@@ -120,7 +120,7 @@ steps:
   - uses: ros-tooling/action-ros-ci@v0.2
     with:
       package-name: my_package
-      target-ros2-distro: galactic
+      target-ros2-distro: humble
       vcs-repo-file-url: /tmp/deps.repos
 ```
 
@@ -135,11 +135,11 @@ Simply use `target-ros1-distro` instead of `target-ros2-distro`.
 steps:
   - uses: ros-tooling/setup-ros@v0.3
     with:
-      required-ros-distributions: melodic
+      required-ros-distributions: noetic
   - uses: ros-tooling/action-ros-ci@v0.2
     with:
       package-name: my_package
-      target-ros1-distro: melodic
+      target-ros1-distro: noetic
 ```
 
 ### Skip tests
@@ -150,11 +150,11 @@ To skip tests and code coverage data processing, set the `skip-tests` option to 
 steps:
   - uses: ros-tooling/setup-ros@v0.3
     with:
-      required-ros-distributions: galactic
+      required-ros-distributions: humble
   - uses: ros-tooling/action-ros-ci@v0.2
     with:
       package-name: my_package
-      target-ros2-distro: galactic
+      target-ros2-distro: humble
       skip-tests: true
 ```
 
@@ -167,11 +167,11 @@ This allows using a `colcon` option/argument that is not exposed by this action'
 steps:
   - uses: ros-tooling/setup-ros@v0.3
     with:
-      required-ros-distributions: galactic
+      required-ros-distributions: humble
   - uses: ros-tooling/action-ros-ci@v0.2
     with:
       package-name: my_package
-      target-ros2-distro: galactic
+      target-ros2-distro: humble
       colcon-defaults: |
         {
           "build": {
@@ -191,7 +191,7 @@ memory corruption bugs.
 steps:
   - uses: ros-tooling/setup-ros@v0.3
     with:
-      required-ros-distributions: galactic
+      required-ros-distributions: humble
   - uses: ros-tooling/action-ros-ci@v0.2
     with:
       colcon-defaults: |
@@ -202,7 +202,7 @@ steps:
         }
       colcon-mixin-repository: https://raw.githubusercontent.com/colcon/colcon-mixin-repository/3e627e0fa30db85aea05a50e2c61a9832664d236/index.yaml
       package-name: my_package
-      target-ros2-distro: galactic
+      target-ros2-distro: humble
 ```
 
 To look for detected memory errors, check the build logs for entries containing `ERROR: AddressSanitizer`. Example:
@@ -227,11 +227,11 @@ preferable to use a `colcon` mixin (through [`colcon-defaults`](#Use-a-colcon-de
 steps:
   - uses: ros-tooling/setup-ros@v0.3
     with:
-      required-ros-distributions: galactic
+      required-ros-distributions: humble
   - uses: ros-tooling/action-ros-ci@v0.2
     with:
       package-name: my_package
-      target-ros2-distro: galactic
+      target-ros2-distro: humble
       colcon-defaults: |
         {
           "build": {
@@ -252,11 +252,11 @@ Generate code coverage information for Python files using the appropriate mixins
 steps:
   - uses: ros-tooling/setup-ros@v0.3
     with:
-      required-ros-distributions: galactic
+      required-ros-distributions: humble
   - uses: ros-tooling/action-ros-ci@v0.2
     with:
       package-name: my_package
-      target-ros2-distro: galactic
+      target-ros2-distro: humble
       colcon-defaults: |
         {
           "build": {
@@ -283,11 +283,11 @@ steps:
   - uses: actions/checkout@v2
   - uses: ros-tooling/setup-ros@v0.3
     with:
-      required-ros-distributions: galactic
+      required-ros-distributions: humble
   - uses: ros-tooling/action-ros-ci@v0.2
     with:
       package-name: my_package
-      target-ros2-distro: galactic
+      target-ros2-distro: humble
       colcon-defaults: |
         {
           "build": {
@@ -330,7 +330,7 @@ steps:
     id: action_ros_ci_step
     with:
       package-name: ament_copyright
-      target-ros2-distro: galactic
+      target-ros2-distro: humble
   - uses: actions/upload-artifact@v1
     with:
       name: colcon-logs


### PR DESCRIPTION
Follow-up to #741

Relates to #738

`setup-ros-docker` images for Humble were recently added: https://github.com/ros-tooling/setup-ros-docker/pull/51

Signed-off-by: Christophe Bedard <bedard.christophe@gmail.com>