### PR TITLE
Rename the https://github.com/ros2/ros2 branch to 'rolling'.

### DIFF
--- a/__tests__/ros-ci.test.ts
+++ b/__tests__/ros-ci.test.ts
@@ -96,7 +96,7 @@ Description of the changes.
 Blah blah.
 
 action-ros-ci-repos-override:   
-action-ros-ci-repos-override: https://raw.githubusercontent.com/ros2/ros2/master/ros2.repos
+action-ros-ci-repos-override: https://raw.githubusercontent.com/ros2/ros2/rolling/ros2.repos
 action-ros-ci-repos-override : https://some.website.repos
  action-ros-ci-repos-override:  https://gist.github.com/some-user/some-gist.repos
  action-ros-ci-repos-supplemental:https://gist.github.com/some-user/some-other-gist.repos
@@ -104,7 +104,7 @@ action-ros-ci-repos-supplemental:  file://path/to/some/file.txt
 `;
 		payload = { pull_request: { body: body } };
 		const expectedOverride = [
-			"https://raw.githubusercontent.com/ros2/ros2/master/ros2.repos",
+			"https://raw.githubusercontent.com/ros2/ros2/rolling/ros2.repos",
 			"https://gist.github.com/some-user/some-gist.repos",
 		];
 		const expectedSupplemental = [

--- a/action.yml
+++ b/action.yml
@@ -69,7 +69,7 @@ inputs:
       Repo file URL passed to vcs to initialize the colcon workspace.
       The URL may point to a local file, such as file://path/to/file.txt.
       For example, for ROS 2 Rolling source repositories, use:
-      https://raw.githubusercontent.com/ros2/ros2/master/ros2.repos
+      https://raw.githubusercontent.com/ros2/ros2/rolling/ros2.repos
     default: ""
   skip-tests:
     default: ""

--- a/dist/index.js
+++ b/dist/index.js
@@ -13662,7 +13662,7 @@ run();
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getReposFilesSupplemental = exports.getReposFilesOverride = void 0;
 // Expecting something like:
-//  action-ros-ci-repos-override: https://raw.githubusercontent.com/ros2/ros2/master/ros2.repos
+//  action-ros-ci-repos-override: https://raw.githubusercontent.com/ros2/ros2/rolling/ros2.repos
 const REGEX_REPOS_FILES_OVERRIDE = /action-ros-ci-repos-override:[ ]*([\S]+)/g;
 const REGEX_REPOS_FILES_SUPPLEMENTAL = /action-ros-ci-repos-supplemental:[ ]*([\S]+)/g;
 /**

--- a/src/dependencies.ts
+++ b/src/dependencies.ts
@@ -1,7 +1,7 @@
 import { WebhookPayload } from "@actions/github/lib/interfaces";
 
 // Expecting something like:
-//  action-ros-ci-repos-override: https://raw.githubusercontent.com/ros2/ros2/master/ros2.repos
+//  action-ros-ci-repos-override: https://raw.githubusercontent.com/ros2/ros2/rolling/ros2.repos
 const REGEX_REPOS_FILES_OVERRIDE = /action-ros-ci-repos-override:[ ]*([\S]+)/g;
 const REGEX_REPOS_FILES_SUPPLEMENTAL =
 	/action-ros-ci-repos-supplemental:[ ]*([\S]+)/g;


### PR DESCRIPTION
That is the new default, so follow it here.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

This is part of https://discourse.ros.org/t/change-default-branch-name-to-rolling-in-ros-2-core/26009/9