### PR TITLE
Filter out newlines from colcon list output

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -13308,7 +13308,7 @@ function installRosdeps(packageSelection, skipKeys, workspaceDir, options, ros1D
 		exit 1
 	fi
 	DISTRO=$1
-	package_paths=$(colcon list --paths-only ${filterNonEmptyJoin(packageSelection)})
+	package_paths=$(colcon list --paths-only ${filterNonEmptyJoin(packageSelection)} | tr '\n' ' ')
 	# suppress errors from unresolved install keys to preserve backwards compatibility
 	# due to difficulty reading names of some non-catkin dependencies in the ros2 core
 	# see https://index.ros.org/doc/ros2/Installation/Foxy/Linux-Development-Setup/#install-dependencies-using-rosdep

--- a/src/action-ros-ci.ts
+++ b/src/action-ros-ci.ts
@@ -166,6 +166,7 @@ async function installRosdeps(
 	ros1Distro?: string,
 	ros2Distro?: string
 ): Promise<number> {
+	const lineEnding = isWindows ? "\r" : "" + "\n";
 	const scriptName = "install_rosdeps.sh";
 	const scriptPath = path.join(workspaceDir, scriptName);
 	const scriptContent = `#!/bin/bash
@@ -177,7 +178,7 @@ async function installRosdeps(
 	DISTRO=$1
 	package_paths=$(colcon list --paths-only ${filterNonEmptyJoin(
 		packageSelection
-	)})
+	)} | tr '${lineEnding}' ' ')
 	# suppress errors from unresolved install keys to preserve backwards compatibility
 	# due to difficulty reading names of some non-catkin dependencies in the ros2 core
 	# see https://index.ros.org/doc/ros2/Installation/Foxy/Linux-Development-Setup/#install-dependencies-using-rosdep


### PR DESCRIPTION
Fixes #766

`colcon list` returns one result per line, which seems to break the console on Windows later on. Just switch from one-result-per-line to space-separated results.

Signed-off-by: Christophe Bedard <christophe.bedard@apex.ai>