### PR TITLE
Move lint job to separate workflow file and check build artifact

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,19 @@
+name: "PR checks"
+on:
+  pull_request:
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  test_lint_and_build:
+    name: "Lint sources and check build artifacts"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3.4.1
+        with:
+          node-version: "12.x"
+      - run: npm install && npm run lint
+      - run: npm run build && git diff --exit-code

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,17 +24,6 @@ jobs:
     steps:
       - run: 'true'
 
-  test_lint:
-    name: "Lint sources"
-    runs-on: ubuntu-latest
-    needs: pre_condition
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3.4.1
-        with:
-          node-version: "12.x"
-      - run: npm install && npm run lint
-
   test_ros:
     name: "Test ROS package"
     runs-on: ubuntu-latest


### PR DESCRIPTION
Copied from `setup-ros`: https://github.com/ros-tooling/setup-ros/blob/57bc9dc0ed672890441ae4fe26e55542b3920506/.github/workflows/pr.yml.

It's quite useful to make sure the `dist/index.js` file has been generated.

Signed-off-by: Christophe Bedard <christophe.bedard@apex.ai>