### PR TITLE
Pull private submodules that use ssh urls

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -15411,6 +15411,18 @@ function run_throw() {
             yield execShellCommand([
                 `/usr/bin/git config --global url.https://x-access-token:${importToken}@github.com.insteadof 'https://github.com'`,
             ], options);
+            // same as last three comands but for ssh urls
+            yield execShellCommand([
+                `/usr/bin/git config --local --unset-all git@github.com:.extraheader || true`,
+            ], options);
+            yield execShellCommand([
+                String.raw `/usr/bin/git submodule foreach --recursive git config --local --name-only --get-regexp 'git@github\.com:.extraheader'` +
+                    ` && git config --local --unset-all 'git@github.com:.extraheader' || true`,
+            ], options);
+            // Use a global insteadof entry because local configs aren't observed by git clone (ssh)
+            yield execShellCommand([
+                `/usr/bin/git config --global url.https://x-access-token:${importToken}@github.com/.insteadof 'git@github.com:'`,
+            ], options);
             if (core.isDebug()) {
                 yield execShellCommand([`/usr/bin/git config --list --show-origin || true`], options);
             }

--- a/src/action-ros-ci.ts
+++ b/src/action-ros-ci.ts
@@ -457,6 +457,27 @@ async function run_throw(): Promise<void> {
 			],
 			options
 		);
+		// same as last three comands but for ssh urls
+		await execShellCommand(
+			[
+				`/usr/bin/git config --local --unset-all git@github.com:.extraheader || true`,
+			],
+			options
+		);
+		await execShellCommand(
+			[
+				String.raw`/usr/bin/git submodule foreach --recursive git config --local --name-only --get-regexp 'git@github\.com:.extraheader'` +
+					` && git config --local --unset-all 'git@github.com:.extraheader' || true`,
+			],
+			options
+		);
+		// Use a global insteadof entry because local configs aren't observed by git clone (ssh)
+		await execShellCommand(
+			[
+				`/usr/bin/git config --global url.https://x-access-token:${importToken}@github.com/.insteadof 'git@github.com:'`,
+			],
+			options
+		);
 		if (core.isDebug()) {
 			await execShellCommand(
 				[`/usr/bin/git config --list --show-origin || true`],


### PR DESCRIPTION
PR to deal this [issue](https://github.com/ros-tooling/action-ros-ci/issues/782). This is a quick workaround to have both https and ssh urls be changed to use a PAT token.