### PR TITLE
Run 'colcon test-result' to print test failures

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -11337,7 +11337,6 @@ function runTests(colconCommandPrefix, options, testPackageSelection, colconExtr
             `colcon`,
             `test`,
             `--event-handlers=console_cohesion+`,
-            `--return-code-on-test-failure`,
             ...testPackageSelection,
             ...colconExtraArgs,
         ];
@@ -11346,6 +11345,15 @@ function runTests(colconCommandPrefix, options, testPackageSelection, colconExtr
         }
         if (doTests) {
             yield execShellCommand([...colconCommandPrefix, ...colconTestCmd], options, false);
+            /**
+             * Display all test results first and ignore the return code. Then, display only failing
+             * tests with their output and let non-zero return code fail the job.
+             */
+            const colconTestResultCmd = ["colcon", "test-result"];
+            const colconTestResultAllCmd = [...colconTestResultCmd, "--all"];
+            const colconTestResultVerboseCmd = [...colconTestResultCmd, "--verbose"];
+            yield execShellCommand([...colconCommandPrefix, ...colconTestResultAllCmd], Object.assign(Object.assign({}, options), { ignoreReturnCode: true }), false);
+            yield execShellCommand([...colconCommandPrefix, ...colconTestResultVerboseCmd], options, false);
         }
         if (doLcovResult) {
             // ignoreReturnCode, check comment above in --initial

--- a/src/action-ros-ci.ts
+++ b/src/action-ros-ci.ts
@@ -239,7 +239,6 @@ async function runTests(
 		`colcon`,
 		`test`,
 		`--event-handlers=console_cohesion+`,
-		`--return-code-on-test-failure`,
 		...testPackageSelection,
 		...colconExtraArgs,
 	];
@@ -250,6 +249,27 @@ async function runTests(
 	if (doTests) {
 		await execShellCommand(
 			[...colconCommandPrefix, ...colconTestCmd],
+			options,
+			false
+		);
+
+		/**
+		 * Display all test results first and ignore the return code. Then, display only failing
+		 * tests with their output and let non-zero return code fail the job.
+		 */
+		const colconTestResultCmd = ["colcon", "test-result"];
+		const colconTestResultAllCmd = [...colconTestResultCmd, "--all"];
+		const colconTestResultVerboseCmd = [...colconTestResultCmd, "--verbose"];
+		await execShellCommand(
+			[...colconCommandPrefix, ...colconTestResultAllCmd],
+			{
+				...options,
+				ignoreReturnCode: true,
+			},
+			false
+		);
+		await execShellCommand(
+			[...colconCommandPrefix, ...colconTestResultVerboseCmd],
 			options,
 			false
 		);


### PR DESCRIPTION
Closes #784

`action-ros-ci` currently runs `colcon test ...` with `--return-code-on-test-failure`, which makes the CI job fail right after that command if any tests fail. Users need to look through the test output to find the test failures, which is a bit annoying.

Instead, remove the `--return-code-on-test-failure` option from the `colcon test ...` command, and use `colcon test-result` instead. Run it first with the `--all` option so that all test results are printed, including the tests that passed. This allows quickly checking what tests ran. Since `colcon test-result` [returns a non-zero error code if any tests failed](https://github.com/colcon/colcon-test-result/blob/1e724a34231e337b0103ef56bca36417a335ed2d/colcon_test_result/verb/test_result.py#L109), ignore the return code here. Then, run `colcon test-result` with the `--verbose` option (only) to show only test results of failed tests along with part of their output. This time, the return code isn't ignored, which makes the CI job fail if there are any failures. This is much closer to the way CI jobs work on ci.ros2.org.

This shouldn't affect the actual outcome of CI jobs; it should only affect the output.

Signed-off-by: Christophe Bedard <christophe.bedard@apex.ai>