### PR TITLE
With github pullrequests work on target repo rather than the source

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -11546,10 +11546,13 @@ done`;
         // being built.
         let repoFullName = process.env.GITHUB_REPOSITORY;
         if (github.context.payload.pull_request) {
-            repoFullName = github.context.payload.pull_request.head.repo.full_name;
+            repoFullName = github.context.payload.pull_request.base.repo.full_name;
         }
         const headRef = process.env.GITHUB_HEAD_REF;
-        const commitRef = headRef || github.context.sha;
+        let commitRef = headRef || github.context.sha;
+        if (github.context.payload.pull_request) {
+            commitRef = github.context.sha;
+        }
         const repoFilePath = path.join(rosWorkspaceDir, "package.repo");
         // Add a random string prefix to avoid naming collisions when checking out the test repository
         const randomStringPrefix = Math.random().toString(36).substring(2, 15);

--- a/src/action-ros-ci.ts
+++ b/src/action-ros-ci.ts
@@ -555,10 +555,13 @@ done`;
 	// being built.
 	let repoFullName = process.env.GITHUB_REPOSITORY as string;
 	if (github.context.payload.pull_request) {
-		repoFullName = github.context.payload.pull_request.head.repo.full_name;
+		repoFullName = github.context.payload.pull_request.base.repo.full_name;
 	}
 	const headRef = process.env.GITHUB_HEAD_REF as string;
-	const commitRef = headRef || github.context.sha;
+	let commitRef = headRef || github.context.sha;
+	if (github.context.payload.pull_request) {
+		commitRef = github.context.sha;
+	}
 	const repoFilePath = path.join(rosWorkspaceDir, "package.repo");
 	// Add a random string prefix to avoid naming collisions when checking out the test repository
 	const randomStringPrefix = Math.random().toString(36).substring(2, 15);


### PR DESCRIPTION
This provides support for private forks, where GITHUB_TOKEN generated by GH in the target repo pull request context does not provide access to the pull request's source repo.

This requires vcstool to be fixed to properly support checking out sources by hash, rather than a branch or tag, because a pull request's source branch does not exist in the destination repository.  Rather, the patch can be accessed as refs/pr/123/head or refs/pr/123/merge.  With github.context.sha being equivalent to the resolved commit hash of refs/pr/123/merge.
