### PR TITLE
Use console_direct event handler for colcon test

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -11337,7 +11337,7 @@ function runTests(colconCommandPrefix, options, testPackageSelection, colconExtr
         let colconTestCmd = [
             `colcon`,
             `test`,
-            `--event-handlers=console_cohesion+`,
+            `--event-handlers=console_direct+`,
             ...testPackageSelection,
             ...colconExtraArgs,
         ];

--- a/src/action-ros-ci.ts
+++ b/src/action-ros-ci.ts
@@ -239,7 +239,7 @@ async function runTests(
 	let colconTestCmd = [
 		`colcon`,
 		`test`,
-		`--event-handlers=console_cohesion+`,
+		`--event-handlers=console_direct+`,
 		...testPackageSelection,
 		...colconExtraArgs,
 	];


### PR DESCRIPTION
`action-ros-ci` currently uses `console_cohesion+` for both `colcon build` and `colcon test`. ci.ros2.org uses `console_cohesion+` for `colcon build` (prints output once package is done being processed) and `console_direct+` for `colcon test` (prints output directly).

Users can override the default event handler selected by `action-ros-ci` using the `extra-colcon-args` input (since those extra args are added on to the end of the `colcon test` call, and CLI arguments override any previous argument), but I think it makes sense to change the default event handler for `colcon test` to `console_direct+`.