### PR TITLE
Add skip-rosdep-install & rosdep-check options

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -141,6 +141,23 @@ jobs:
         run: |
           dpkg -s ros-humble-osrf-testing-tools-cpp
 
+  test_ros2_iron_skip_rosdep_install:
+    name: Build and test current ROS repo
+    runs-on: ubuntu-latest
+    needs: pre_condition
+    container:
+      image: rostooling/setup-ros-docker:ubuntu-jammy-ros-iron-ros-base-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./
+        with:
+          import-token: ${{ secrets.GITHUB_TOKEN }}
+          target-ros2-distro: iron
+          package-name: ament_copyright
+          vcs-repo-file-url: "https://raw.githubusercontent.com/ros2/ros2/release-iron-20231120/ros2.repos"
+          skip-rosdep-install: true
+          rosdep-check: true
+
   test_private_repo:
     name: "Test with private repos"
     runs-on: ubuntu-22.04

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -142,7 +142,7 @@ jobs:
           dpkg -s ros-humble-osrf-testing-tools-cpp
 
   test_ros2_iron_skip_rosdep_install:
-    name: Build and test current ROS repo
+    name: Test rosdep check/skip install options
     runs-on: ubuntu-latest
     needs: pre_condition
     container:
@@ -151,7 +151,6 @@ jobs:
       - uses: actions/checkout@v3
       - uses: ./
         with:
-          import-token: ${{ secrets.GITHUB_TOKEN }}
           target-ros2-distro: iron
           package-name: ament_copyright
           vcs-repo-file-url: "https://raw.githubusercontent.com/ros2/ros2/release-iron-20231120/ros2.repos"

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ This action builds and tests a [ROS](http://wiki.ros.org/) or [ROS 2](https://do
    1. [Generate and process code coverage data](#Generate-and-process-code-coverage-data)
    1. [Store `colcon` logs as build artifacts](#Store-colcon-logs-as-build-artifacts)
    1. [Use with private repos](#Use-with-private-repos)
+   1. [Skip `rosdep install`](#Skip-rosdep-install)
    1. [Interdependent pull requests or merge requests](#Interdependent-pull-requests-or-merge-requests)
 1. [Developing](#Developing)
 1. [License](#License)
@@ -383,6 +384,26 @@ steps:
       # If there are private dependencies (e.g., in a file provided through vcs-repo-file-url), a PAT is required
       import-token: ${{ secrets.REPO_TOKEN }}
       # ...
+```
+
+### Skip rosdep install
+
+Include an option to bypass `rosdep install` for workflow that uses specific docker image and better control of dependencies. To check for missing dependencies within the workflow's image, user can run with `rosdep-check: true` flag.
+
+```yaml
+runs-on: ubuntu-latest
+container:
+  image: rostooling/setup-ros-docker:ubuntu-jammy-ros-iron-ros-base-latest
+steps:
+  # ...
+  - uses: ros-tooling/action-ros-ci@v0.3.6
+    with:
+      import-token: ${{ secrets.GITHUB_TOKEN }}
+      target-ros2-distro: iron
+      package-name: ament_copyright
+      vcs-repo-file-url: "https://raw.githubusercontent.com/ros2/ros2/release-iron-20231120/ros2.repos"
+      skip-rosdep-install: true
+      rosdep-check: true
 ```
 
 ### Interdependent pull requests or merge requests

--- a/README.md
+++ b/README.md
@@ -386,7 +386,7 @@ steps:
       # ...
 ```
 
-### Skip rosdep install
+### Skip `rosdep install`
 
 Include an option to bypass `rosdep install` for workflow that uses specific docker image and better control of dependencies. To check for missing dependencies within the workflow's image, user can run with `rosdep-check: true` flag.
 
@@ -396,9 +396,8 @@ container:
   image: rostooling/setup-ros-docker:ubuntu-jammy-ros-iron-ros-base-latest
 steps:
   # ...
-  - uses: ros-tooling/action-ros-ci@v0.3.6
+  - uses: ros-tooling/action-ros-ci@v0.3
     with:
-      import-token: ${{ secrets.GITHUB_TOKEN }}
       target-ros2-distro: iron
       package-name: ament_copyright
       vcs-repo-file-url: "https://raw.githubusercontent.com/ros2/ros2/release-iron-20231120/ros2.repos"

--- a/action.yml
+++ b/action.yml
@@ -77,6 +77,12 @@ inputs:
       Skip tests and code coverage data processing.
       Set to 'true'.
     required: false
+  skip-rosdep-install:
+    default: ""
+    description: |
+      Skip rosdep install.
+      Set to 'true'.
+    required: false
   rosdep-skip-keys:
     default: ""
     description: |

--- a/action.yml
+++ b/action.yml
@@ -83,6 +83,12 @@ inputs:
       Skip rosdep install.
       Set to 'true'.
     required: false
+  rosdep-check:
+    default: ""
+    description: |
+      Check ros dependency when use with skip-rosdep-install.
+      Set to 'true'.
+    required: false
   rosdep-skip-keys:
     default: ""
     description: |

--- a/action.yml
+++ b/action.yml
@@ -86,7 +86,7 @@ inputs:
   rosdep-check:
     default: ""
     description: |
-      Check ros dependency when use with skip-rosdep-install.
+      Check dependencies of packages using 'rosdep check'. Must be used with skip-rosdep-install.
       Set to 'true'.
     required: false
   rosdep-skip-keys:

--- a/dist/index.js
+++ b/dist/index.js
@@ -11418,6 +11418,7 @@ function run_throw() {
         const vcsRepoFileUrlListAsString = core.getInput("vcs-repo-file-url") || "";
         let vcsRepoFileUrlList = vcsRepoFileUrlListAsString.split(RegExp("\\s"));
         const skipTests = core.getInput("skip-tests") === "true";
+        const skipRosdepInstall = core.getInput("skip-rosdep-install") === "true";
         // Check if PR overrides/adds supplemental repos files
         const vcsReposOverride = dep.getReposFilesOverride(github.context.payload);
         const vcsReposSupplemental = dep.getReposFilesSupplemental(github.context.payload);
@@ -11572,7 +11573,7 @@ done`;
         }
         // rosdep does not really work on Windows, so do not use it
         // See: https://github.com/ros-infrastructure/rosdep/issues/610
-        if (!isWindows) {
+        if (!isWindows && !skipRosdepInstall) {
             yield installRosdeps(buildPackageSelection, rosdepSkipKeysSelection, rosWorkspaceDir, options, targetRos1Distro, targetRos2Distro);
         }
         if (colconDefaults.includes(`"mixin"`) && colconMixinRepo !== "") {

--- a/src/action-ros-ci.ts
+++ b/src/action-ros-ci.ts
@@ -357,6 +357,7 @@ async function run_throw(): Promise<void> {
 	const vcsRepoFileUrlListAsString = core.getInput("vcs-repo-file-url") || "";
 	let vcsRepoFileUrlList = vcsRepoFileUrlListAsString.split(RegExp("\\s"));
 	const skipTests = core.getInput("skip-tests") === "true";
+	const skipRosdepInstall = core.getInput("skip-rosdep-install") === "true";
 
 	// Check if PR overrides/adds supplemental repos files
 	const vcsReposOverride = dep.getReposFilesOverride(github.context.payload);
@@ -586,7 +587,7 @@ done`;
 	}
 	// rosdep does not really work on Windows, so do not use it
 	// See: https://github.com/ros-infrastructure/rosdep/issues/610
-	if (!isWindows) {
+	if (!isWindows && !skipRosdepInstall) {
 		await installRosdeps(
 			buildPackageSelection,
 			rosdepSkipKeysSelection,

--- a/src/action-ros-ci.ts
+++ b/src/action-ros-ci.ts
@@ -204,6 +204,50 @@ async function installRosdeps(
 }
 
 /**
+ * Check ROS dependencies have been satisfied for the workspace.
+ */
+async function checkRosdeps(
+	packageSelection: string[],
+	skipKeys: string[],
+	workspaceDir: string,
+	options: im.ExecOptions,
+	ros1Distro?: string,
+	ros2Distro?: string
+): Promise<number> {
+	const scriptName = "check_rosdeps.sh";
+	const scriptPath = path.join(workspaceDir, scriptName);
+	const scriptContent = `#!/bin/bash
+	set -euxo pipefail
+	if [ $# != 1 ]; then
+		echo "Specify rosdistro name as single argument to this script"
+		exit 1
+	fi
+	DISTRO=$1
+	package_paths=$(colcon list --paths-only ${filterNonEmptyJoin(
+		packageSelection
+	)})
+	rosdep check --from-paths $package_paths --ignore-src --skip-keys "${filterNonEmptyJoin(
+		skipKeys
+	)}" --rosdistro $DISTRO`;
+	fs.writeFileSync(scriptPath, scriptContent, { mode: 0o766 });
+
+	let exitCode = 0;
+	if (ros1Distro) {
+		exitCode += await execShellCommand(
+			[`./${scriptName} ${ros1Distro}`],
+			options
+		);
+	}
+	if (ros2Distro) {
+		exitCode += await execShellCommand(
+			[`./${scriptName} ${ros2Distro}`],
+			options
+		);
+	}
+	return exitCode;
+}
+
+/**
  * Run tests and process & aggregate coverage results.
  *
  * @param colconCommandPrefix the prefix to use before colcon commands
@@ -358,6 +402,7 @@ async function run_throw(): Promise<void> {
 	let vcsRepoFileUrlList = vcsRepoFileUrlListAsString.split(RegExp("\\s"));
 	const skipTests = core.getInput("skip-tests") === "true";
 	const skipRosdepInstall = core.getInput("skip-rosdep-install") === "true";
+	const rosdepCheck = core.getInput("rosdep-check") === "true";
 
 	// Check if PR overrides/adds supplemental repos files
 	const vcsReposOverride = dep.getReposFilesOverride(github.context.payload);
@@ -589,6 +634,17 @@ done`;
 	// See: https://github.com/ros-infrastructure/rosdep/issues/610
 	if (!isWindows && !skipRosdepInstall) {
 		await installRosdeps(
+			buildPackageSelection,
+			rosdepSkipKeysSelection,
+			rosWorkspaceDir,
+			options,
+			targetRos1Distro,
+			targetRos2Distro
+		);
+	}
+
+	if (skipRosdepInstall && rosdepCheck) {
+		await checkRosdeps(
 			buildPackageSelection,
 			rosdepSkipKeysSelection,
 			rosWorkspaceDir,


### PR DESCRIPTION
Closes #829 

This PR adds an optional argument for skipping `rosdep install` in the action (`skip-rosdep-install`) and an optional argument to run `rosdep check` (`rosdep-check`), which only works if `skip-rosdep-install` is also enabled.