### PR TITLE
read the GitHub server URL from the 'GITHUB_SERVER_URL' env variable

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -11554,12 +11554,13 @@ done`;
         // if ref is set this overrides anything calculated above
         commitRef = core.getInput("ref") || commitRef;
         const repoFilePath = path.join(rosWorkspaceDir, "package.repo");
+        const githubServerUrl = process.env.GITHUB_SERVER_URL;
         // Add a random string prefix to avoid naming collisions when checking out the test repository
         const randomStringPrefix = Math.random().toString(36).substring(2, 15);
         const repoFileContent = `repositories:
   ${randomStringPrefix}/${repo["repo"]}:
     type: git
-    url: 'https://github.com/${repoFullName}.git'
+    url: '${githubServerUrl}/${repoFullName}.git'
     version: '${commitRef}'`;
         fs_1.default.writeFileSync(repoFilePath, repoFileContent);
         yield execShellCommand(["vcs import --force --recursive src/ < package.repo"], options);

--- a/src/action-ros-ci.ts
+++ b/src/action-ros-ci.ts
@@ -563,12 +563,13 @@ done`;
 	// if ref is set this overrides anything calculated above
 	commitRef = core.getInput("ref") || commitRef;
 	const repoFilePath = path.join(rosWorkspaceDir, "package.repo");
+	const githubServerUrl = process.env.GITHUB_SERVER_URL as string;
 	// Add a random string prefix to avoid naming collisions when checking out the test repository
 	const randomStringPrefix = Math.random().toString(36).substring(2, 15);
 	const repoFileContent = `repositories:
   ${randomStringPrefix}/${repo["repo"]}:
     type: git
-    url: 'https://github.com/${repoFullName}.git'
+    url: '${githubServerUrl}/${repoFullName}.git'
     version: '${commitRef}'`;
 	fs.writeFileSync(repoFilePath, repoFileContent);
 	await execShellCommand(


### PR DESCRIPTION
This PR replaces the hardcoded URL `https://github.com` with the content of the environment variable `GITHUB_SERVER_URL` in order to allow using this action on GitHub Enterprise instances. Fixes https://github.com/ros-tooling/action-ros-ci/issues/831.