### PR TITLE
Lower dependabot update frequency

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,12 +3,11 @@ updates:
   - package-ecosystem: npm
     directory: "/"
     schedule:
-      interval: daily
-      time: "16:00"
-    open-pull-requests-limit: 1
+      interval: weekly
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch"]
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
-      interval: daily
-      time: "16:00"
-    open-pull-requests-limit: 1
+      interval: weekly


### PR DESCRIPTION
Lower dependabot update frequency because we don't release _that_ frequently:

1. Ignore patch updates for npm dependencies
1. Set update interval to weekly, but don't limit the number of open PRs