### PR TITLE
Make 'pip3 freeze' optional

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -11610,7 +11610,7 @@ done`;
             yield checkRosdeps(buildPackageSelection, rosdepSkipKeysSelection, rosWorkspaceDir, options, targetRos1Distro, targetRos2Distro);
         }
         // Print list of Python packages and their version
-        yield execShellCommand(["pip3", "freeze"], options);
+        yield execShellCommand(["pip3 freeze || true"], options);
         if (colconDefaults.includes(`"mixin"`) && colconMixinRepo !== "") {
             yield execShellCommand([`colcon`, `mixin`, `add`, `default`, `${colconMixinRepo}`], options, false);
             yield execShellCommand([`colcon`, `mixin`, `update`, `default`], options, false);

--- a/src/action-ros-ci.ts
+++ b/src/action-ros-ci.ts
@@ -657,7 +657,7 @@ done`;
 	}
 
 	// Print list of Python packages and their version
-	await execShellCommand(["pip3", "freeze"], options);
+	await execShellCommand(["pip3 freeze || true"], options);
 
 	if (colconDefaults.includes(`"mixin"`) && colconMixinRepo !== "") {
 		await execShellCommand(


### PR DESCRIPTION
Follow-up to #867 and #862

We cannot assume that `pip` is installed. This can happen when using `action-ros-ci`, but not `setup-ros` or the `setup-ros-docker`  images.