### PR TITLE
Ignore dependabot major version updates for @types/node

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,9 @@ updates:
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-patch"]
+      # Since we're pinned to a specific version of Node.js, ignore major updates
+      - dependency-name: "@types/node"
+        update-types: ["version-update:semver-major"]
   - package-ecosystem: github-actions
     directory: "/"
     schedule:


### PR DESCRIPTION
Similar to https://github.com/ros-tooling/setup-ros/pull/724.