### PR TITLE
Do not ignore 'rosdep install' failures/errors

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -30878,7 +30878,7 @@ function installRosdeps(packageSelection, skipKeys, workspaceDir, options, ros1D
 	# suppress errors from unresolved install keys to preserve backwards compatibility
 	# due to difficulty reading names of some non-catkin dependencies in the ros2 core
 	# see https://index.ros.org/doc/ros2/Installation/Foxy/Linux-Development-Setup/#install-dependencies-using-rosdep
-	rosdep install -r --from-paths $package_paths --ignore-src --skip-keys "rti-connext-dds-5.3.1 rti-connext-dds-6.0.1 ${filterNonEmptyJoin(skipKeys)}" --rosdistro $DISTRO -y || true`;
+	rosdep install -r --from-paths $package_paths --ignore-src --skip-keys "rti-connext-dds-5.3.1 rti-connext-dds-6.0.1 ${filterNonEmptyJoin(skipKeys)}" --rosdistro $DISTRO -y`;
         fs_1.default.writeFileSync(scriptPath, scriptContent, { mode: 0o766 });
         let exitCode = 0;
         if (ros1Distro) {

--- a/src/action-ros-ci.ts
+++ b/src/action-ros-ci.ts
@@ -202,7 +202,7 @@ async function installRosdeps(
 	# see https://index.ros.org/doc/ros2/Installation/Foxy/Linux-Development-Setup/#install-dependencies-using-rosdep
 	rosdep install -r --from-paths $package_paths --ignore-src --skip-keys "rti-connext-dds-5.3.1 rti-connext-dds-6.0.1 ${filterNonEmptyJoin(
 		skipKeys,
-	)}" --rosdistro $DISTRO -y || true`;
+	)}" --rosdistro $DISTRO -y`;
 	fs.writeFileSync(scriptPath, scriptContent, { mode: 0o766 });
 
 	let exitCode = 0;


### PR DESCRIPTION
Closes #954

This `|| true` after `rosdep install` has been in `action-ros-ci` since the very first implementation: https://github.com/ros-tooling/action-ros-ci/blame/b08ee66c5236c0e9df3b57a86f851e9ca66956af/src/action-ros2-ci.ts#L66-L72. The comment specifically says:

```
    // For "latest" builds, rosdep often misses some keys, adding "|| true", to
    // ignore those failures, as it is often non-critical.
```

This might not be a valid reason. After all, if some keys are missing, then some dependencies will be missing. Also, as laid out in #954, this hides actual errors reported by `rosdep` about dependencies declared in `package.xml` files.