### PR TITLE
Fix Docker from Source CI

### DIFF
--- a/.github/workflows/repo_file_for_test.repos
+++ b/.github/workflows/repo_file_for_test.repos
@@ -11,7 +11,7 @@ repositories:
   ament_lint:
     type: git
     url: https://github.com/ament/ament_lint.git
-    version: ae431edfeb2d1fb7e92c37c67bce9c4237e9ac43
+    version: 0.19.1
   ament_package:
     type: git
     url: https://github.com/ament/ament_package.git

--- a/.github/workflows/repo_file_for_test_dirs_with_same_name_as_repo.repos
+++ b/.github/workflows/repo_file_for_test_dirs_with_same_name_as_repo.repos
@@ -9,7 +9,7 @@ repositories:
   foo/action-ros-ci/bar:
     type: git
     url: https://github.com/ament/ament_lint.git
-    version: ae431edfeb2d1fb7e92c37c67bce9c4237e9ac43
+    version: 0.19.1
   # Test having a duplicate of the test repo
   ros-tooling/action-ros-ci:
     type: git

--- a/.github/workflows/repo_file_for_test_dirs_with_same_name_as_repo_noble.repos
+++ b/.github/workflows/repo_file_for_test_dirs_with_same_name_as_repo_noble.repos
@@ -9,7 +9,7 @@ repositories:
   foo/action-ros-ci/bar:
     type: git
     url: https://github.com/ament/ament_lint.git
-    version: 060dcfd382a29eb642f7c5f65a925826a6e67b3a
+    version: 0.19.1
   # Test having a duplicate of the test repo
   ros-tooling/action-ros-ci:
     type: git

--- a/.github/workflows/repo_file_for_test_noble.repos
+++ b/.github/workflows/repo_file_for_test_noble.repos
@@ -11,7 +11,7 @@ repositories:
   ament_lint:
     type: git
     url: https://github.com/ament/ament_lint.git
-    version: 060dcfd382a29eb642f7c5f65a925826a6e67b3a
+    version: 0.19.1
   ament_package:
     type: git
     url: https://github.com/ament/ament_package.git


### PR DESCRIPTION
Update the `ament_lint` pin to a non-broken version for `jazzy` and `rolling`