### PR TITLE
Ignore rosdep key for new RTI Connext DDS 7.3.0 version

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -30878,7 +30878,7 @@ function installRosdeps(packageSelection, skipKeys, workspaceDir, options, ros1D
 	# suppress errors from unresolved install keys to preserve backwards compatibility
 	# due to difficulty reading names of some non-catkin dependencies in the ros2 core
 	# see https://index.ros.org/doc/ros2/Installation/Foxy/Linux-Development-Setup/#install-dependencies-using-rosdep
-	rosdep install -r --from-paths $package_paths --ignore-src --skip-keys "rti-connext-dds-5.3.1 rti-connext-dds-6.0.1 ${filterNonEmptyJoin(skipKeys)}" --rosdistro $DISTRO -y`;
+	rosdep install -r --from-paths $package_paths --ignore-src --skip-keys "rti-connext-dds-5.3.1 rti-connext-dds-6.0.1 rti-connext-dds-7.3.0 ${filterNonEmptyJoin(skipKeys)}" --rosdistro $DISTRO -y`;
         fs_1.default.writeFileSync(scriptPath, scriptContent, { mode: 0o766 });
         let exitCode = 0;
         if (ros1Distro) {

--- a/src/action-ros-ci.ts
+++ b/src/action-ros-ci.ts
@@ -200,7 +200,7 @@ async function installRosdeps(
 	# suppress errors from unresolved install keys to preserve backwards compatibility
 	# due to difficulty reading names of some non-catkin dependencies in the ros2 core
 	# see https://index.ros.org/doc/ros2/Installation/Foxy/Linux-Development-Setup/#install-dependencies-using-rosdep
-	rosdep install -r --from-paths $package_paths --ignore-src --skip-keys "rti-connext-dds-5.3.1 rti-connext-dds-6.0.1 ${filterNonEmptyJoin(
+	rosdep install -r --from-paths $package_paths --ignore-src --skip-keys "rti-connext-dds-5.3.1 rti-connext-dds-6.0.1 rti-connext-dds-7.3.0 ${filterNonEmptyJoin(
 		skipKeys,
 	)}" --rosdistro $DISTRO -y`;
 	fs.writeFileSync(scriptPath, scriptContent, { mode: 0o766 });


### PR DESCRIPTION
ROS 2 Rolling switched to version 7.3.0 (before Kilted): https://github.com/ros2/rmw_connextdds/pull/181.

This PR is similar to https://github.com/ros2/ros2_documentation/pull/5227. Just ignore the rosdep key for RTI Connext DDS 7.3.0. 

Relates to this `setup-ros` PR: https://github.com/ros-tooling/setup-ros/pull/798.

Relates a bit to https://github.com/ros2/ros2_documentation/issues/5226