### PR TITLE
Support rosdep-check without skip-rosdep-install

### DIFF
--- a/src/action-ros-ci.ts
+++ b/src/action-ros-ci.ts
@@ -670,10 +670,9 @@ done`;
 			core.setFailed(`Unsupported distribution ${dist}`);
 		}
 	}
-	// rosdep does not really work on Windows, so do not use it
-	// See: https://github.com/ros-infrastructure/rosdep/issues/610
-	if (!isWindows && !skipRosdepInstall) {
-		await installRosdeps(
+
+	if (rosdepCheck) {
+		await checkRosdeps(
 			buildPackageSelection,
 			rosdepSkipKeysSelection,
 			rosWorkspaceDir,
@@ -683,8 +682,10 @@ done`;
 		);
 	}
 
-	if (skipRosdepInstall && rosdepCheck) {
-		await checkRosdeps(
+	// rosdep does not really work on Windows, so do not use it
+	// See: https://github.com/ros-infrastructure/rosdep/issues/610
+	if (!isWindows && !skipRosdepInstall) {
+		await installRosdeps(
 			buildPackageSelection,
 			rosdepSkipKeysSelection,
 			rosWorkspaceDir,


### PR DESCRIPTION
Why `rosdep-check` cannot be used independently of `skip-rosdep-install`? 

I have an issue when testing my package on new ROS distros if some dependencies are not released yet, `action-ros-ci` action doesn't fail when rosdep says:
`
ERROR: the following packages/stacks could not have their rosdep keys resolved to system dependencies:
`

In the code, `rosdep install` uses `-r` option, meaning "Continue installing despite errors.":
https://github.com/ros-tooling/action-ros-ci/blob/8dce0379055992c29df0f6fe13d5d47b75b70aec/src/action-ros-ci.ts#L201-L204

My current workaround is to be able to use `rosdep check` before `rosdep install` is called. In this pull request, I switched the order and removed the requirement of `skip-rosdep-install` to use `rosdep-check` option.