### PR TITLE
Add option to set ssh port for servers using non-standard SSH port

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -118,6 +118,13 @@ inputs:
       Scheduled events default to latest commit of default branch.
       Set this if you want the scheduled job to run on on a specific branch.
     required: false
+  git-ssh-port:
+    default: ""
+    description: |
+      SSH port used to access repositories.
+      Needed to overide the ssh url with https when using a private server
+      using a non-standard SSH port for git.
+    required: false
 outputs:
   ros-workspace-directory-name:
     description: |

--- a/action.yml
+++ b/action.yml
@@ -122,7 +122,7 @@ inputs:
     default: ""
     description: |
       SSH port used to access repositories.
-      Needed to overide the ssh url with https when using a private server
+      Needed to override the ssh url with https when using a private server
       using a non-standard SSH port for git.
     required: false
 outputs:


### PR DESCRIPTION
Hi dear maintainers,

I know that this action has been developed exclusively to be used on Github.
But other forges like [Forgejo](https://forgejo.org/) provide actions runners compatible with the Github ones.
I have been able to use your action on a private Forgejo instance but on my server, the SSH port of the Git server is not the default port 22. Hence my rosinstall files contains ssh urls with a specific port, in the format:

```
ssh://git@domain_name.com:port/org/repo.git
```

instead of the Github:

```
git@github.com:org/repo.git
```

By adding the `ssh-port` input for the action, I have managed to adapt the url replaced with the `insteaof` git config to make it work for my use-case.

Because the git url with a port has already a trailing `/` like on HTTPS urls, the config entry is the same, hence the `--add` argument in that case.

I have not added an entry in the README because this is an advanced usage of the action and it is documented in `action.yml`.

I have been able to test this change both on my private Forgejo setup and on Github with a private repo with ssh url in the rosinstall.