### PR TITLE
Use windows-2022 instead of -2019 due to deprecation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,11 +68,11 @@ jobs:
       matrix:
         os:
           # - macOS-latest
-          - windows-2019
+          - windows-2022
         ros_distribution: [humble, jazzy, kilted]
     env:
-      INSTALL_TYPE: ${{ matrix.os == 'windows-2019' && 'merged' || 'default' }}
-      INSTALL_PATH: ${{ matrix.os == 'windows-2019' && 'install/share' || 'install' }}
+      INSTALL_TYPE: ${{ startsWith(matrix.os, 'windows') && 'merged' || 'default' }}
+      INSTALL_PATH: ${{ startsWith(matrix.os, 'windows') && 'install/share' || 'install' }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4.4.0
@@ -233,13 +233,13 @@ jobs:
             ros_distribution: kilted
           - os: ubuntu:24.04
             ros_distribution: rolling
-          - os: windows-2019
+          - os: windows-2022
             ros_distribution: humble
-          - os: windows-2019
+          - os: windows-2022
             ros_distribution: jazzy
-          - os: windows-2019
+          - os: windows-2022
             ros_distribution: kilted
-          - os: windows-2019
+          - os: windows-2022
             ros_distribution: rolling
           # - os: macOS-latest
           #   ros_distribution: humble
@@ -251,8 +251,8 @@ jobs:
           #   ros_distribution: rolling
     env:
       DISTRO_REPOS_URL: "https://raw.githubusercontent.com/ros2/ros2/${{ matrix.ros_distribution }}/ros2.repos"
-      INSTALL_TYPE: ${{ matrix.os == 'windows-2019' && 'merged' || 'default' }}
-      INSTALL_PATH: ${{ matrix.os == 'windows-2019' && 'install/share' || 'install' }}
+      INSTALL_TYPE: ${{ startsWith(matrix.os, 'windows') && 'merged' || 'default' }}
+      INSTALL_PATH: ${{ startsWith(matrix.os, 'windows') && 'install/share' || 'install' }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4.4.0

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ For reference, these are the minimum tools needed by the action, which are provi
 - `colcon-coveragepy-result` (Optional)
 - `colcon-mixin` (Optional)
 
-**Note**: for Windows, `action-ros-ci` currently needs to be run on `windows-2019` or needs another action to install Visual Studio 2019.
+**Note**: for Windows, ROS 2 currently only officially supports Visual Studio 2019, but GitHub has dropped support for the `windows-2019` runner image, so we can only use `windows-2022` (Visual Studio 2022) or newer.
 
 ## Overview
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -30803,7 +30803,7 @@ function execShellCommand(command_1, options_1) {
                 "/S",
                 "/C",
                 "call",
-                "%programfiles(x86)%\\Microsoft Visual Studio\\2019\\Enterprise\\VC\\Auxiliary\\Build\\vcvars64.bat",
+                "%programfiles(x86)%\\Microsoft Visual Studio\\2022\\Enterprise\\VC\\Auxiliary\\Build\\vcvars64.bat",
                 "&&",
                 ...(use_bash ? [`C:\\Program Files\\Git\\bin\\bash.exe`, `-c`] : []),
                 ...command,

--- a/dist/index.js
+++ b/dist/index.js
@@ -30803,7 +30803,7 @@ function execShellCommand(command_1, options_1) {
                 "/S",
                 "/C",
                 "call",
-                "%programfiles(x86)%\\Microsoft Visual Studio\\2022\\Enterprise\\VC\\Auxiliary\\Build\\vcvars64.bat",
+                "%programfiles%\\Microsoft Visual Studio\\2022\\Enterprise\\VC\\Auxiliary\\Build\\vcvars64.bat",
                 "&&",
                 ...(use_bash ? [`C:\\Program Files\\Git\\bin\\bash.exe`, `-c`] : []),
                 ...command,

--- a/src/action-ros-ci.ts
+++ b/src/action-ros-ci.ts
@@ -107,7 +107,7 @@ export async function execShellCommand(
 			"/S",
 			"/C",
 			"call",
-			"%programfiles(x86)%\\Microsoft Visual Studio\\2022\\Enterprise\\VC\\Auxiliary\\Build\\vcvars64.bat",
+			"%programfiles%\\Microsoft Visual Studio\\2022\\Enterprise\\VC\\Auxiliary\\Build\\vcvars64.bat",
 			"&&",
 			...(use_bash ? [`C:\\Program Files\\Git\\bin\\bash.exe`, `-c`] : []),
 			...command,

--- a/src/action-ros-ci.ts
+++ b/src/action-ros-ci.ts
@@ -107,7 +107,7 @@ export async function execShellCommand(
 			"/S",
 			"/C",
 			"call",
-			"%programfiles(x86)%\\Microsoft Visual Studio\\2019\\Enterprise\\VC\\Auxiliary\\Build\\vcvars64.bat",
+			"%programfiles(x86)%\\Microsoft Visual Studio\\2022\\Enterprise\\VC\\Auxiliary\\Build\\vcvars64.bat",
 			"&&",
 			...(use_bash ? [`C:\\Program Files\\Git\\bin\\bash.exe`, `-c`] : []),
 			...command,


### PR DESCRIPTION
See https://github.com/actions/runner-images/issues/12045

See the change to the VS path between 2019 and 2022:

1. 2019: https://github.com/actions/runner-images/blob/win19/20250113.1/images/windows/Windows2019-Readme.md#visual-studio-enterprise-2019
2. 2022: https://github.com/actions/runner-images/blob/releases/win22/20250623/images/windows/Windows2022-Readme.md#visual-studio-enterprise-2022