### PR TITLE
Skip rosdep key `rti-connext-dds-7.7.0`

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -30879,7 +30879,7 @@ function installRosdeps(packageSelection, skipKeys, workspaceDir, options, ros1D
 	# suppress errors from unresolved install keys to preserve backwards compatibility
 	# due to difficulty reading names of some non-catkin dependencies in the ros2 core
 	# see https://index.ros.org/doc/ros2/Installation/Foxy/Linux-Development-Setup/#install-dependencies-using-rosdep
-	rosdep install -r --from-paths $package_paths --ignore-src --skip-keys "rti-connext-dds-5.3.1 rti-connext-dds-6.0.1 rti-connext-dds-7.3.0 ${filterNonEmptyJoin(skipKeys)}" --rosdistro $DISTRO -y`;
+	rosdep install -r --from-paths $package_paths --ignore-src --skip-keys "rti-connext-dds-5.3.1 rti-connext-dds-6.0.1 rti-connext-dds-7.3.0 rti-connext-dds-7.7.0 ${filterNonEmptyJoin(skipKeys)}" --rosdistro $DISTRO -y`;
         fs_1.default.writeFileSync(scriptPath, scriptContent, { mode: 0o766 });
         let exitCode = 0;
         if (ros1Distro) {

--- a/src/action-ros-ci.ts
+++ b/src/action-ros-ci.ts
@@ -201,7 +201,7 @@ async function installRosdeps(
 	# suppress errors from unresolved install keys to preserve backwards compatibility
 	# due to difficulty reading names of some non-catkin dependencies in the ros2 core
 	# see https://index.ros.org/doc/ros2/Installation/Foxy/Linux-Development-Setup/#install-dependencies-using-rosdep
-	rosdep install -r --from-paths $package_paths --ignore-src --skip-keys "rti-connext-dds-5.3.1 rti-connext-dds-6.0.1 rti-connext-dds-7.3.0 ${filterNonEmptyJoin(
+	rosdep install -r --from-paths $package_paths --ignore-src --skip-keys "rti-connext-dds-5.3.1 rti-connext-dds-6.0.1 rti-connext-dds-7.3.0 rti-connext-dds-7.7.0 ${filterNonEmptyJoin(
 		skipKeys,
 	)}" --rosdistro $DISTRO -y`;
 	fs.writeFileSync(scriptPath, scriptContent, { mode: 0o766 });


### PR DESCRIPTION
Since https://github.com/ros2/rmw_connextdds/pull/219 the action-ros-ci is failing with

```
2026-04-09T05:31:53.0141968Z ERROR: the following rosdeps failed to install
2026-04-09T05:31:53.0142827Z   apt: command [apt-get install -y rti-connext-dds-7.7.0-ros] failed
2026-04-09T05:31:53.0143747Z   apt: Failed to detect successful installation of [rti-connext-dds-7.7.0-ros]
```