### PR TITLE
Fix CMake and setuptools deprecation (fixs failures)

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -11,8 +11,8 @@ jobs:
     name: "Lint sources and check build artifacts"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-node@v4.4.0
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version: "24.x"
       - run: npm install && npm run lint

--- a/.github/workflows/repo_file_for_test.repos
+++ b/.github/workflows/repo_file_for_test.repos
@@ -11,7 +11,7 @@ repositories:
   ament_lint:
     type: git
     url: https://github.com/ament/ament_lint.git
-    version: 0.19.3
+    version: 0.20.6
   ament_package:
     type: git
     url: https://github.com/ament/ament_package.git

--- a/.github/workflows/repo_file_for_test.repos
+++ b/.github/workflows/repo_file_for_test.repos
@@ -7,12 +7,12 @@ repositories:
   ament_cmake:
     type: git
     url: https://github.com/ament/ament_cmake.git
-    version: 0.8.1
+    version: 1.3.14
   ament_lint:
     type: git
     url: https://github.com/ament/ament_lint.git
-    version: 0.19.1
+    version: 0.19.3
   ament_package:
     type: git
     url: https://github.com/ament/ament_package.git
-    version: 0.8.1
+    version: 0.14.2

--- a/.github/workflows/repo_file_for_test_cpp_package.repos
+++ b/.github/workflows/repo_file_for_test_cpp_package.repos
@@ -1,8 +1,8 @@
 # repo file only containing osrf_testing_tools_cpp
 # This repository has been chosen because it does depend on anything, as of
-# 1.5.3.
+# 2.3.1.
 repositories:
   osrf_testing_tools_cpp:
     type: git
     url: https://github.com/osrf/osrf_testing_tools_cpp.git
-    version: 1.5.3
+    version: 2.3.1

--- a/.github/workflows/repo_file_for_test_dirs_with_same_name_as_repo.repos
+++ b/.github/workflows/repo_file_for_test_dirs_with_same_name_as_repo.repos
@@ -4,7 +4,7 @@ repositories:
   action-ros-ci/foo:
     type: git
     url: https://github.com/ament/ament_cmake.git
-    version: 1.3.14
+    version: 2.7.5
   # Test having a child directory with the same name as the test repo
   foo/action-ros-ci/bar:
     type: git

--- a/.github/workflows/repo_file_for_test_dirs_with_same_name_as_repo.repos
+++ b/.github/workflows/repo_file_for_test_dirs_with_same_name_as_repo.repos
@@ -9,7 +9,7 @@ repositories:
   foo/action-ros-ci/bar:
     type: git
     url: https://github.com/ament/ament_lint.git
-    version: 0.19.3
+    version: 0.20.6
   # Test having a duplicate of the test repo
   ros-tooling/action-ros-ci:
     type: git

--- a/.github/workflows/repo_file_for_test_dirs_with_same_name_as_repo.repos
+++ b/.github/workflows/repo_file_for_test_dirs_with_same_name_as_repo.repos
@@ -4,12 +4,12 @@ repositories:
   action-ros-ci/foo:
     type: git
     url: https://github.com/ament/ament_cmake.git
-    version: 1.3.12
+    version: 1.3.14
   # Test having a child directory with the same name as the test repo
   foo/action-ros-ci/bar:
     type: git
     url: https://github.com/ament/ament_lint.git
-    version: 0.19.2
+    version: 0.19.3
   # Test having a duplicate of the test repo
   ros-tooling/action-ros-ci:
     type: git

--- a/.github/workflows/repo_file_for_test_dirs_with_same_name_as_repo_noble.repos
+++ b/.github/workflows/repo_file_for_test_dirs_with_same_name_as_repo_noble.repos
@@ -4,12 +4,12 @@ repositories:
   action-ros-ci/foo:
     type: git
     url: https://github.com/ament/ament_cmake.git
-    version: 2.3.2
+    version: 2.7.5
   # Test having a child directory with the same name as the test repo
   foo/action-ros-ci/bar:
     type: git
     url: https://github.com/ament/ament_lint.git
-    version: 0.19.3
+    version: 0.20.6
   # Test having a duplicate of the test repo
   ros-tooling/action-ros-ci:
     type: git

--- a/.github/workflows/repo_file_for_test_dirs_with_same_name_as_repo_noble.repos
+++ b/.github/workflows/repo_file_for_test_dirs_with_same_name_as_repo_noble.repos
@@ -9,7 +9,7 @@ repositories:
   foo/action-ros-ci/bar:
     type: git
     url: https://github.com/ament/ament_lint.git
-    version: 0.19.1
+    version: 0.19.3
   # Test having a duplicate of the test repo
   ros-tooling/action-ros-ci:
     type: git

--- a/.github/workflows/repo_file_for_test_noble.repos
+++ b/.github/workflows/repo_file_for_test_noble.repos
@@ -7,12 +7,12 @@ repositories:
   ament_cmake:
     type: git
     url: https://github.com/ament/ament_cmake.git
-    version: 2.3.2
+    version: 2.4.0
   ament_lint:
     type: git
     url: https://github.com/ament/ament_lint.git
-    version: 0.19.1
+    version: 0.19.3
   ament_package:
     type: git
     url: https://github.com/ament/ament_package.git
-    version: 0.16.3
+    version: 0.16.5

--- a/.github/workflows/repo_file_for_test_noble.repos
+++ b/.github/workflows/repo_file_for_test_noble.repos
@@ -7,12 +7,12 @@ repositories:
   ament_cmake:
     type: git
     url: https://github.com/ament/ament_cmake.git
-    version: 2.4.0
+    version: 2.9.0
   ament_lint:
     type: git
     url: https://github.com/ament/ament_lint.git
-    version: 0.19.3
+    version: 0.21.1
   ament_package:
     type: git
     url: https://github.com/ament/ament_package.git
-    version: 0.16.5
+    version: 0.19.0

--- a/.github/workflows/repo_file_for_test_rosdep_distro.repos
+++ b/.github/workflows/repo_file_for_test_rosdep_distro.repos
@@ -2,9 +2,9 @@
 # This repository has been chosen because it depends on other packages
 # e.g. test_interface_files
 #
-# https://github.com/ros2/rcl_interfaces/tree/1.2.2
+# https://github.com/ros2/rcl_interfaces/tree/1.2.3
 repositories:
   rcl_interfaces:
     type: git
     url: https://github.com/ros2/rcl_interfaces.git
-    version: 1.2.2
+    version: 1.2.3

--- a/.github/workflows/ros_tutorials.repos
+++ b/.github/workflows/ros_tutorials.repos
@@ -1,10 +1,10 @@
 # repo file only containing ros_tutorials
 # This repository has been chosen because it does depend on anything, as of
-# 1.4.3
+# 1.10.9
 #
-# https://github.com/ros/ros_tutorials/tree/1.4.3
+# https://github.com/ros/ros_tutorials/tree/1.10.9
 repositories:
   ros_tutorials:
     type: git
     url: https://github.com/ros/ros_tutorials.git
-    version: 1.4.3
+    version: 1.10.9

--- a/.github/workflows/ros_tutorials.repos
+++ b/.github/workflows/ros_tutorials.repos
@@ -1,10 +1,10 @@
 # repo file only containing ros_tutorials
 # This repository has been chosen because it does depend on anything, as of
-# 0.10.3
+# 1.4.3
 #
-# https://github.com/ros/ros_tutorials/tree/0.10.3
+# https://github.com/ros/ros_tutorials/tree/1.4.3
 repositories:
   ros_tutorials:
     type: git
     url: https://github.com/ros/ros_tutorials.git
-    version: 0.10.3
+    version: 1.4.3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -102,7 +102,7 @@ jobs:
       image: rostooling/setup-ros-docker:ubuntu-jammy-latest
     needs: pre_condition
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
       - uses: ./
         with:
           package-name: rmw
@@ -116,7 +116,7 @@ jobs:
       image: rostooling/setup-ros-docker:ubuntu-jammy-latest
     needs: pre_condition
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
       # Skip installing test_depend dependency and verifies it isn't installed.
       - uses: ./
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,7 +46,7 @@ jobs:
       image: ${{ matrix.container_image }}
     steps:
       - uses: actions/checkout@v5
-      - uses: actions/setup-node@v4.4.0
+      - uses: actions/setup-node@v5
         with:
           node-version: "24.x"
       - run: .github/workflows/build-and-test.sh
@@ -74,8 +74,8 @@ jobs:
       INSTALL_TYPE: ${{ startsWith(matrix.os, 'windows') && 'merged' || 'default' }}
       INSTALL_PATH: ${{ startsWith(matrix.os, 'windows') && 'install/share' || 'install' }}
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-node@v4.4.0
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version: "24.x"
       - run: .github/workflows/build-and-test.sh
@@ -150,7 +150,7 @@ jobs:
     # We don't have access to the secret token for the test repo on a fork
     if: ${{ !github.event.repository.fork && !github.event.pull_request.head.repo.fork }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
       - uses: ./
         with:
           import-token: ${{ secrets.TOKEN_PRIVATE_REPO_TEST }}
@@ -195,8 +195,8 @@ jobs:
     container:
       image: ${{ matrix.container_image }}
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-node@v4.4.0
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version: "24.x"
       - run: .github/workflows/build-and-test.sh
@@ -264,8 +264,8 @@ jobs:
       INSTALL_TYPE: ${{ startsWith(matrix.os, 'windows') && 'merged' || 'default' }}
       INSTALL_PATH: ${{ startsWith(matrix.os, 'windows') && 'install/share' || 'install' }}
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-node@v4.4.0
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version: "24.x"
       - run: .github/workflows/build-and-test.sh
@@ -488,8 +488,8 @@ jobs:
     container:
       image: ${{ matrix.container_image }}
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-node@v4.4.0
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version: "24.x"
       - run: .github/workflows/build-and-test.sh

--- a/src/action-ros-ci.ts
+++ b/src/action-ros-ci.ts
@@ -202,7 +202,7 @@ async function installRosdeps(
 	# suppress errors from unresolved install keys to preserve backwards compatibility
 	# due to difficulty reading names of some non-catkin dependencies in the ros2 core
 	# see https://index.ros.org/doc/ros2/Installation/Foxy/Linux-Development-Setup/#install-dependencies-using-rosdep
-	rosdep install -r --from-paths $package_paths --ignore-src --skip-keys "rti-connext-dds-5.3.1 rti-connext-dds-6.0.1 rti-connext-dds-7.3.0 rti-connext-dds-7.7.0 ${filterNonEmptyJoin(
+	rosdep update && rosdep install -r --from-paths $package_paths --ignore-src --skip-keys "rti-connext-dds-5.3.1 rti-connext-dds-6.0.1 rti-connext-dds-7.3.0 rti-connext-dds-7.7.0 ${filterNonEmptyJoin(
 		skipKeys,
 	)}" --rosdistro $DISTRO -y`;
 	fs.writeFileSync(scriptPath, scriptContent, { mode: 0o766 });

--- a/src/action-ros-ci.ts
+++ b/src/action-ros-ci.ts
@@ -202,7 +202,7 @@ async function installRosdeps(
 	# suppress errors from unresolved install keys to preserve backwards compatibility
 	# due to difficulty reading names of some non-catkin dependencies in the ros2 core
 	# see https://index.ros.org/doc/ros2/Installation/Foxy/Linux-Development-Setup/#install-dependencies-using-rosdep
-	rosdep update && rosdep install -r --from-paths $package_paths --ignore-src --skip-keys "rti-connext-dds-5.3.1 rti-connext-dds-6.0.1 rti-connext-dds-7.3.0 rti-connext-dds-7.7.0 ${filterNonEmptyJoin(
+	rosdep install -r --from-paths $package_paths --ignore-src --skip-keys "rti-connext-dds-5.3.1 rti-connext-dds-6.0.1 rti-connext-dds-7.3.0 rti-connext-dds-7.7.0 ${filterNonEmptyJoin(
 		skipKeys,
 	)}" --rosdistro $DISTRO -y`;
 	fs.writeFileSync(scriptPath, scriptContent, { mode: 0o766 });


### PR DESCRIPTION
ros lirical tests fail due to some libraries that either use old deprecated setuptools configurations or require cmake versions from 3.10. Updating the versions of the libraries to be used in the repo_test file (using the humble version) solves the problem.